### PR TITLE
add Contrast WCAG Result

### DIFF
--- a/src/components/ColorConvert/ColorContrastChecker.vue
+++ b/src/components/ColorConvert/ColorContrastChecker.vue
@@ -1,0 +1,113 @@
+<template>
+  <div class="section contrast-checker--wrapper">
+    <div class="label"><span class="heading">WCAG</span> result :</div>
+    <div class="content">
+      <div class="contrast-result--items">
+        <div
+          class="contrast-result--item aa-level--lg"
+          :class="{ passed: contrast.aa_lvl_lg, [color]: true }"
+        >
+          <span class="item-subtitle">Large Text</span>
+          <span class="item-title">AA</span>
+        </div>
+        <div
+          class="contrast-result--item aa-level--sm"
+          :class="{ passed: contrast.aa_lvl_sm, [color]: true }"
+        >
+          <span class="item-subtitle">Normal Text</span>
+          <span class="item-title">AA</span>
+        </div>
+        <div
+          class="contrast-result--item aaa-level--lg"
+          :class="{ passed: contrast.aaa_lvl_lg, [color]: true }"
+        >
+          <span class="item-subtitle">Large Text</span>
+          <span class="item-title">AAA</span>
+        </div>
+        <div
+          class="contrast-result--item aaa-level--sm"
+          :class="{ passed: contrast.aaa_lvl_sm, [color]: true }"
+        >
+          <span class="item-subtitle">Normal Text</span>
+          <span class="item-title">AAA</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { calculateContrast } from "../../services/colors";
+
+export default {
+  name: "ColorContrastChecker",
+  props: {
+    color: String,
+    foreground: Array,
+    background: Array,
+  },
+  computed: {
+    contrast() {
+      return calculateContrast(this.foreground, this.background);
+    },
+  },
+};
+</script>
+
+<style lang="scss">
+.contrast-checker--wrapper {
+  margin-top: 1rem;
+
+  .label {
+    margin-bottom: 0.5rem;
+  }
+  .content {
+    width: 100%;
+
+    .contrast-result--items {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      .contrast-result--item {
+        background-color: rgba(0, 0, 0, 0.1);
+        border-radius: 3px;
+        padding: 8px;
+        text-align: center;
+        position: relative;
+
+        &:not(:last-child) {
+          margin-right: 8px;
+        }
+
+        &.passed:after {
+          content: "";
+          position: absolute;
+          bottom: 4px;
+          right: 4px;
+          width: 16px;
+          height: 16px;
+        }
+        &.passed.white:after {
+          background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' enable-background='new 0 0 24 24' height='16px' viewBox='0 0 24 24' width='16px' fill='%23FFFFFF'%3E%3Cg%3E%3Crect fill='none' height='24' width='24'/%3E%3C/g%3E%3Cg%3E%3Cg%3E%3Cpath d='M23,11.99l-2.44-2.79l0.34-3.69l-3.61-0.82L15.4,1.5L12,2.96L8.6,1.5L6.71,4.69L3.1,5.5L3.44,9.2L1,11.99l2.44,2.79 l-0.34,3.7l3.61,0.82L8.6,22.5l3.4-1.47l3.4,1.46l1.89-3.19l3.61-0.82l-0.34-3.69L23,11.99z M19.05,13.47l-0.56,0.65l0.08,0.85 l0.18,1.95l-1.9,0.43l-0.84,0.19l-0.44,0.74l-0.99,1.68l-1.78-0.77L12,18.85l-0.79,0.34l-1.78,0.77l-0.99-1.67l-0.44-0.74 l-0.84-0.19l-1.9-0.43l0.18-1.96l0.08-0.85l-0.56-0.65l-1.29-1.47l1.29-1.48l0.56-0.65L5.43,9.01L5.25,7.07l1.9-0.43l0.84-0.19 l0.44-0.74l0.99-1.68l1.78,0.77L12,5.14l0.79-0.34l1.78-0.77l0.99,1.68l0.44,0.74l0.84,0.19l1.9,0.43l-0.18,1.95l-0.08,0.85 l0.56,0.65l1.29,1.47L19.05,13.47z'/%3E%3Cpolygon points='10.09,13.75 7.77,11.42 6.29,12.91 10.09,16.72 17.43,9.36 15.95,7.87'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+        }
+        &.passed.black:after {
+          background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' enable-background='new 0 0 24 24' height='16px' viewBox='0 0 24 24' width='16px' fill='%23333333'%3E%3Cg%3E%3Crect fill='none' height='24' width='24'/%3E%3C/g%3E%3Cg%3E%3Cg%3E%3Cpath d='M23,11.99l-2.44-2.79l0.34-3.69l-3.61-0.82L15.4,1.5L12,2.96L8.6,1.5L6.71,4.69L3.1,5.5L3.44,9.2L1,11.99l2.44,2.79 l-0.34,3.7l3.61,0.82L8.6,22.5l3.4-1.47l3.4,1.46l1.89-3.19l3.61-0.82l-0.34-3.69L23,11.99z M19.05,13.47l-0.56,0.65l0.08,0.85 l0.18,1.95l-1.9,0.43l-0.84,0.19l-0.44,0.74l-0.99,1.68l-1.78-0.77L12,18.85l-0.79,0.34l-1.78,0.77l-0.99-1.67l-0.44-0.74 l-0.84-0.19l-1.9-0.43l0.18-1.96l0.08-0.85l-0.56-0.65l-1.29-1.47l1.29-1.48l0.56-0.65L5.43,9.01L5.25,7.07l1.9-0.43l0.84-0.19 l0.44-0.74l0.99-1.68l1.78,0.77L12,5.14l0.79-0.34l1.78-0.77l0.99,1.68l0.44,0.74l0.84,0.19l1.9,0.43l-0.18,1.95l-0.08,0.85 l0.56,0.65l1.29,1.47L19.05,13.47z'/%3E%3Cpolygon points='10.09,13.75 7.77,11.42 6.29,12.91 10.09,16.72 17.43,9.36 15.95,7.87'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+        }
+
+        > span {
+          display: block;
+
+          &.item-subtitle {
+            font-size: 12.5px;
+            margin-bottom: 0.25rem;
+          }
+          &.item-title {
+            font-size: 18px;
+            font-weight: bold;
+          }
+        }
+      }
+    }
+  }
+}
+</style>

--- a/src/components/ColorConvert/ColorContrastChecker.vue
+++ b/src/components/ColorConvert/ColorContrastChecker.vue
@@ -5,28 +5,44 @@
       <div class="contrast-result--items">
         <div
           class="contrast-result--item aa-level--lg"
-          :class="{ passed: contrast.aa_lvl_lg, [color]: true }"
+          :class="{
+            passed: contrast.aa_lvl_lg,
+            fail: !contrast.aa_lvl_lg,
+            [color]: true,
+          }"
         >
           <span class="item-subtitle">Large Text</span>
           <span class="item-title">AA</span>
         </div>
         <div
           class="contrast-result--item aa-level--sm"
-          :class="{ passed: contrast.aa_lvl_sm, [color]: true }"
+          :class="{
+            passed: contrast.aa_lvl_sm,
+            fail: !contrast.aa_lvl_sm,
+            [color]: true,
+          }"
         >
           <span class="item-subtitle">Normal Text</span>
           <span class="item-title">AA</span>
         </div>
         <div
           class="contrast-result--item aaa-level--lg"
-          :class="{ passed: contrast.aaa_lvl_lg, [color]: true }"
+          :class="{
+            passed: contrast.aaa_lvl_lg,
+            fail: !contrast.aaa_lvl_lg,
+            [color]: true,
+          }"
         >
           <span class="item-subtitle">Large Text</span>
           <span class="item-title">AAA</span>
         </div>
         <div
           class="contrast-result--item aaa-level--sm"
-          :class="{ passed: contrast.aaa_lvl_sm, [color]: true }"
+          :class="{
+            passed: contrast.aaa_lvl_sm,
+            fail: !contrast.aaa_lvl_sm,
+            [color]: true,
+          }"
         >
           <span class="item-subtitle">Normal Text</span>
           <span class="item-title">AAA</span>
@@ -71,7 +87,7 @@ export default {
       .contrast-result--item {
         background-color: rgba(0, 0, 0, 0.1);
         border-radius: 3px;
-        padding: 8px;
+        padding: 8px 14px;
         text-align: center;
         position: relative;
 
@@ -79,7 +95,7 @@ export default {
           margin-right: 8px;
         }
 
-        &.passed:after {
+        &:after {
           content: "";
           position: absolute;
           bottom: 4px;
@@ -93,12 +109,18 @@ export default {
         &.passed.black:after {
           background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' enable-background='new 0 0 24 24' height='16px' viewBox='0 0 24 24' width='16px' fill='%23333333'%3E%3Cg%3E%3Crect fill='none' height='24' width='24'/%3E%3C/g%3E%3Cg%3E%3Cg%3E%3Cpath d='M23,11.99l-2.44-2.79l0.34-3.69l-3.61-0.82L15.4,1.5L12,2.96L8.6,1.5L6.71,4.69L3.1,5.5L3.44,9.2L1,11.99l2.44,2.79 l-0.34,3.7l3.61,0.82L8.6,22.5l3.4-1.47l3.4,1.46l1.89-3.19l3.61-0.82l-0.34-3.69L23,11.99z M19.05,13.47l-0.56,0.65l0.08,0.85 l0.18,1.95l-1.9,0.43l-0.84,0.19l-0.44,0.74l-0.99,1.68l-1.78-0.77L12,18.85l-0.79,0.34l-1.78,0.77l-0.99-1.67l-0.44-0.74 l-0.84-0.19l-1.9-0.43l0.18-1.96l0.08-0.85l-0.56-0.65l-1.29-1.47l1.29-1.48l0.56-0.65L5.43,9.01L5.25,7.07l1.9-0.43l0.84-0.19 l0.44-0.74l0.99-1.68l1.78,0.77L12,5.14l0.79-0.34l1.78-0.77l0.99,1.68l0.44,0.74l0.84,0.19l1.9,0.43l-0.18,1.95l-0.08,0.85 l0.56,0.65l1.29,1.47L19.05,13.47z'/%3E%3Cpolygon points='10.09,13.75 7.77,11.42 6.29,12.91 10.09,16.72 17.43,9.36 15.95,7.87'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
         }
+        &.fail.white:after {
+          background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='16px' viewBox='0 0 24 24' width='16px' fill='%23FFFFFF'%3E%3Cpath d='M0 0h24v24H0V0z' fill='none'/%3E%3Cpath d='M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zM4 12c0-4.42 3.58-8 8-8 1.85 0 3.55.63 4.9 1.69L5.69 16.9C4.63 15.55 4 13.85 4 12zm8 8c-1.85 0-3.55-.63-4.9-1.69L18.31 7.1C19.37 8.45 20 10.15 20 12c0 4.42-3.58 8-8 8z'/%3E%3C/svg%3E");
+        }
+        &.fail.black:after {
+          background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='16px' viewBox='0 0 24 24' width='16px' fill='%23333333'%3E%3Cpath d='M0 0h24v24H0V0z' fill='none'/%3E%3Cpath d='M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zM4 12c0-4.42 3.58-8 8-8 1.85 0 3.55.63 4.9 1.69L5.69 16.9C4.63 15.55 4 13.85 4 12zm8 8c-1.85 0-3.55-.63-4.9-1.69L18.31 7.1C19.37 8.45 20 10.15 20 12c0 4.42-3.58 8-8 8z'/%3E%3C/svg%3E");
+        }
 
         > span {
           display: block;
 
           &.item-subtitle {
-            font-size: 12.5px;
+            font-size: 11.5px;
             margin-bottom: 0.25rem;
           }
           &.item-title {

--- a/src/services/colors.js
+++ b/src/services/colors.js
@@ -37,7 +37,8 @@ export const colorValidate = (from, value) => {
       const hsl = getColorProperties("hsl");
       if (typeof value === "object" && value.length === hsl.inputLength) {
         const mapValue = value.filter(
-          (item, index) =>  (typeof item === "number" && item <= hsl.inputMaxLength(index))
+          (item, index) =>
+            typeof item === "number" && item <= hsl.inputMaxLength(index)
         );
 
         return mapValue.length === hsl.inputLength ? true : false;
@@ -314,4 +315,46 @@ export const getColorProperties = (type) => {
   };
 
   return properties[type];
+};
+
+/**
+ * @param {Number[]} rgb color
+ * @returns {Number}
+ */
+export const getLuminance = (rgb) => {
+  var a = rgb.map(function (v) {
+    v /= 255;
+    return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+  });
+  return a[0] * 0.2126 + a[1] * 0.7152 + a[2] * 0.0722;
+};
+
+/**
+ *
+ * @param {Number[]|String} foreground
+ * @param {Number[]|String} background
+ * @returns
+ */
+export const calculateContrast = (foreground, background) => {
+  if (typeof foreground === "string") {
+    foreground = converter.hex.toRgb(foreground);
+  }
+  if (typeof background === "string") {
+    background = converter.hex.toRgb(background);
+  }
+
+  const fg_luminance = getLuminance(foreground);
+  const bg_luminance = getLuminance(background);
+
+  const ratio =
+    fg_luminance > bg_luminance
+      ? (bg_luminance + 0.05) / (fg_luminance + 0.05)
+      : (fg_luminance + 0.05) / (bg_luminance + 0.05);
+
+  return {
+    aa_lvl_lg: ratio < 1 / 3,
+    aa_lvl_sm: ratio < 1 / 4.5,
+    aaa_lvl_lg: ratio < 1 / 4.5,
+    aaa_lvl_sm: ratio < 1 / 7,
+  };
 };

--- a/src/services/colors.js
+++ b/src/services/colors.js
@@ -163,12 +163,13 @@ export const generateRandomColor = () => {
  * @param {Boolean} animated
  **/
 export const calculateColor = (type, value, animated) => {
-  const { cssVariable, colors, contrast, gradients } = generateCssColor({
-    type, value
-  });
+  const { variable, cssVariable, colors, contrast, gradients } =
+    generateCssColor({
+      type,
+      value,
+    });
 
-  document.body.style.cssText = cssVariable
-    .join("");
+  document.body.style.cssText = cssVariable.join("");
 
   document.body.style.cssText += animated
     ? `transition: background-color 0.5s cubic-bezier(0.4, 0, 0.2, 1);`
@@ -184,6 +185,7 @@ export const calculateColor = (type, value, animated) => {
     colors,
     contrast,
     gradients: gradients.reverse(),
+    variable,
   };
 };
 
@@ -191,9 +193,10 @@ export const generateCssColor = ({ type, value }) => {
   const colors = colorConvert(type, value);
   const contrast = yiqContrastRatio(colors.rgb);
   const gradients = generateGrandients(colors.hex);
+  const rgb = getColorProperties("rgb");
 
   const textColor =
-    contrast.result === "black" ? gradients[7] : `rgb(${colors.rgb.join(", ")})`;
+    contrast.result === "black" ? gradients[7] : rgb.toString(colors.rgb);
   const secondaryColor =
     contrast.result === "black" ? gradients[1] : gradients[7];
   const darkColor = contrast.result === "black" ? gradients[7] : gradients[1];
@@ -203,7 +206,7 @@ export const generateCssColor = ({ type, value }) => {
     .replace(")", ", 0.98)");
 
   let cssVariable = [
-    ["primary-color", `rgb(${colors.rgb.join(", ")})`],
+    ["primary-color", rgb.toString(colors.rgb)],
     ["secondary-color", secondaryColor],
     ["text-color", textColor],
     ["dark-color", darkColor],
@@ -211,21 +214,33 @@ export const generateCssColor = ({ type, value }) => {
     ["contrast-color", contrast.result],
   ];
 
-  cssVariable = cssVariable.filter(([name, value]) => name !== null)
+  let variable = {
+    primary: normalize(colors.rgb),
+    secondary: rgb.toArray(secondaryColor),
+    text: rgb.toArray(textColor),
+    contrast: contrast.result === "black" ? [0, 0, 0] : [255, 255, 255],
+  };
+
+  cssVariable = cssVariable
+    .filter(([name, value]) => name !== null)
     .map(([name, value]) => {
       return `--${name}: ${value};`;
     });
 
-  for (const [ index, gradient ] of Object.entries(gradients.reverse())) {
-    const n = ((Number(index) + 1) * 100);
+  for (const [index, gradient] of Object.entries(gradients.reverse())) {
+    const n = (Number(index) + 1) * 100;
 
     cssVariable.push(`--gradient-${n}: ${gradient};`);
   }
 
   return {
-    colors, contrast, gradients, cssVariable
-  }
-}
+    colors,
+    contrast,
+    gradients,
+    cssVariable,
+    variable,
+  };
+};
 
 /**
  * Get color properties by type
@@ -239,7 +254,7 @@ export const getColorProperties = (type) => {
   const properties = {
     hex: {
       inputLength: 1,
-      inputMaxLength () {
+      inputMaxLength() {
         return 6;
       },
       inputType: "text",
@@ -253,18 +268,31 @@ export const getColorProperties = (type) => {
     },
     rgb: {
       inputLength: 3,
-      inputMaxLength () {
+      inputMaxLength() {
         return 255;
       },
       inputType: "number",
       toString(color) {
         return `rgb(${normalize(color).join(", ")})`;
       },
+      /**
+       * @param {String[]} colors
+       * @return {Number[]} rgb array of number
+       */
+      toArray(color) {
+        const numbs = color
+          .replace("rgb(", "")
+          .replace(")", "")
+          .replace(" ", "")
+          .split(",");
+
+        return normalize(numbs);
+      },
     },
     hsl: {
       inputLength: 3,
-      inputMaxLength (i) {
-        const length = [ 360, 100, 100 ];
+      inputMaxLength(i) {
+        const length = [360, 100, 100];
         if (typeof i == "undefined") return length;
         return length[i];
       },
@@ -275,7 +303,7 @@ export const getColorProperties = (type) => {
     },
     cmyk: {
       inputLength: 4,
-      inputMaxLength () {
+      inputMaxLength() {
         return 100;
       },
       inputType: "number",

--- a/src/store/app.js
+++ b/src/store/app.js
@@ -5,6 +5,12 @@ export const useAppStore = defineStore({
   state: () => ({
     contrast: "white",
     historyPage: false,
+    colors: {
+      primary: [33, 33, 33],
+      secondary: [33, 33, 33],
+      text: [33, 33, 33],
+      contrast: [255, 255, 255],
+    },
   }),
   actions: {
     setContrast(contrast) {
@@ -12,6 +18,14 @@ export const useAppStore = defineStore({
     },
     toggleHistoryPage() {
       this.historyPage = !this.historyPage;
+    },
+    setColors({ primary, secondary, text, contrast }) {
+      this.colors = {
+        primary,
+        secondary,
+        text,
+        contrast,
+      };
     },
   },
 });

--- a/src/views/ColorConvert.vue
+++ b/src/views/ColorConvert.vue
@@ -10,6 +10,11 @@
           @toggleStyle="toggleModalStyle"
         ></color-input>
         <color-contrast :contrast="contrast"></color-contrast>
+        <color-contrast-checker
+          :foreground="colors.text"
+          :background="colors.contrast"
+          :color="contrastColor"
+        ></color-contrast-checker>
       </div>
     </div>
     <div class="navbar">
@@ -42,6 +47,7 @@ import { mapState, mapActions } from "pinia";
 
 import History from "../components/History.vue";
 import ColorContrast from "../components/ColorConvert/ColorContrast.vue";
+import ColorContrastChecker from "../components/ColorConvert/ColorContrastChecker.vue";
 import ColorGradient from "../components/ColorConvert/ColorGradient.vue";
 import ColorInput from "../components/ColorConvert/ColorInput.vue";
 import ButtonConvert from "../components/ColorConvert/ButtonConvert.vue";
@@ -57,6 +63,7 @@ import { normalize } from "../services/utils";
 export default {
   components: {
     ColorContrast,
+    ColorContrastChecker,
     ButtonRandomColor,
     ColorGradient,
     ColorInput,
@@ -87,6 +94,7 @@ export default {
     this.setSelectedType();
   },
   computed: {
+    ...mapState(useAppStore, ["colors"]),
     ...mapState(useDataStore, ["bookmarks", "history"]),
     hexColor() {
       const hex = this.types.find((type) => type.id === "hex");
@@ -103,7 +111,7 @@ export default {
     },
   },
   methods: {
-    ...mapActions(useAppStore, ["setContrast"]),
+    ...mapActions(useAppStore, ["setContrast", "setColors"]),
     ...mapActions(useDataStore, ["addHistory"]),
     initialize() {
       const params = this.$route.params;
@@ -134,7 +142,11 @@ export default {
       this.gradients = gradients;
     },
     onColorChanged([id, value]) {
-      const { colors, contrast, gradients } = calculateColor(id, value, true);
+      const { colors, contrast, gradients, variable } = calculateColor(
+        id,
+        value,
+        true
+      );
 
       this.contrast = contrast.yiq;
       this.gradients = gradients;
@@ -146,6 +158,7 @@ export default {
       });
 
       this.setContrast(contrast.result);
+      this.setColors(variable);
       this.addHistory({
         type: this.activeColor.id,
         value: this.activeColor.value,


### PR DESCRIPTION
## From Web.Dev
The WebAIM guidelines recommend an AA (minimum) contrast ratio of 4.5:1 for all text. An exception is made for very large text (120-150% larger than the default body text), for which the ratio can go down to 3:1. Notice the difference in the contrast ratios shown below.

![image](https://user-images.githubusercontent.com/24630806/125105342-91616800-e108-11eb-8f27-2091a8a834b5.png)

## And this what's contrast result look like

![Screenshot from 2021-07-09 22-55-30](https://user-images.githubusercontent.com/24630806/125105560-c8d01480-e108-11eb-9962-4abdb411d654.png)

![Screenshot from 2021-07-09 22-54-36](https://user-images.githubusercontent.com/24630806/125105563-ca014180-e108-11eb-854d-11647352f8b6.png)
