### PR TITLE
feat/upgrade: upgrade to Vue v3.2 and Vite v2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,15 +11,15 @@
         "comlink": "^4.3.1",
         "matercolors": "^2.2.10",
         "notyf": "^3.10.0",
-        "pinia": "^2.0.0-beta.3",
-        "vue": "^3.2.2",
+        "pinia": "^2.0.0-rc.6",
+        "vue": "^3.2.4",
         "vue-i18n": "^9.1.7",
         "vue-router": "^4.0.8"
       },
       "devDependencies": {
         "@intlify/vite-plugin-vue-i18n": "^2.4.0",
         "@vitejs/plugin-vue": "^1.4.0",
-        "@vue/compiler-sfc": "^3.0.5",
+        "@vue/compiler-sfc": "^3.2.4",
         "sass": "^1.34.1",
         "vite": "^2.5.0",
         "vite-plugin-pwa": "^0.8.1"
@@ -2082,9 +2082,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.4.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.13.tgz",
-      "integrity": "sha512-bLL69sKtd25w7p1nvg9pigE4gtKVpGTPojBFLMkGHXuUgap2sLqQt2qUnqmVCDfzGUL0DRNZP+1prIZJbMeAXg==",
+      "version": "16.7.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.1.tgz",
+      "integrity": "sha512-ncRdc45SoYJ2H4eWU9ReDfp3vtFqDYhjOsKlFFUDEn8V1Bgr2RjYal8YT5byfadWIRluhPFU6JiDOl0H6Sl87A==",
       "dev": true
     },
     "node_modules/@types/resolve": {
@@ -2115,41 +2115,39 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.1.tgz",
-      "integrity": "sha512-UEJf2ZGww5wGVdrWIXIZo04KdJFGPmI2bHRUsBZ3AdyCAqJ5ykRXKOBn1OR1hvA2YzimudOEyHM+DpbBv91Kww==",
-      "dev": true,
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.4.tgz",
+      "integrity": "sha512-c8NuQq7mUXXxA4iqD5VUKpyVeklK53+DMbojYMyZ0VPPrb0BUWrZWFiqSDT+MFDv0f6Hv3QuLiHWb1BWMXBbrw==",
       "dependencies": {
         "@babel/parser": "^7.12.0",
         "@babel/types": "^7.12.0",
-        "@vue/shared": "3.2.1",
+        "@vue/shared": "3.2.4",
         "estree-walker": "^2.0.1",
         "source-map": "^0.6.1"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.1.tgz",
-      "integrity": "sha512-tXg8tkPb3j54zNfWqoao9T1JI41yWPz8TROzmif/QNNA46eq8/SRuRsBd36i47GWaz7mh+yg3vOJ87/YBjcMyQ==",
-      "dev": true,
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.4.tgz",
+      "integrity": "sha512-uj1nwO4794fw2YsYas5QT+FU/YGrXbS0Qk+1c7Kp1kV7idhZIghWLTjyvYibpGoseFbYLPd+sW2/noJG5H04EQ==",
       "dependencies": {
-        "@vue/compiler-core": "3.2.1",
-        "@vue/shared": "3.2.1"
+        "@vue/compiler-core": "3.2.4",
+        "@vue/shared": "3.2.4"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.1.tgz",
-      "integrity": "sha512-fVLdme5RZVkBt+jxv2LCSRM72o4FX7BR2eu2FpjjEi1kEtUMKBDnjKwGWy7TyhTju0t0CocctyoM+G56vH7NpQ==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.4.tgz",
+      "integrity": "sha512-GM+ouDdDzhqgkLmBH4bgq4kiZxJQArSppJiZHWHIx9XRaefHLmc1LBNPmN8ivm4SVfi2i7M2t9k8ZnjsScgzPQ==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.13.9",
         "@babel/types": "^7.13.0",
         "@types/estree": "^0.0.48",
-        "@vue/compiler-core": "3.2.1",
-        "@vue/compiler-dom": "3.2.1",
-        "@vue/compiler-ssr": "3.2.1",
-        "@vue/shared": "3.2.1",
+        "@vue/compiler-core": "3.2.4",
+        "@vue/compiler-dom": "3.2.4",
+        "@vue/compiler-ssr": "3.2.4",
+        "@vue/shared": "3.2.4",
         "consolidate": "^0.16.0",
         "estree-walker": "^2.0.1",
         "hash-sum": "^2.0.0",
@@ -2163,13 +2161,13 @@
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.1.tgz",
-      "integrity": "sha512-6YAOtQunuEyYlVSjK1F7a7BXi7rxVfiTiJ0Ro7eq0q0MNCFV9Z+sN68lfa/E4ABVb0ledEY/Rt8kL23nwCoTCQ==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.4.tgz",
+      "integrity": "sha512-bKZuXu9/4XwsFHFWIKQK+5kN7mxIIWmMmT2L4VVek7cvY/vm3p4WTsXYDGZJy0htOTXvM2ifr6sflg012T0hsw==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-dom": "3.2.1",
-        "@vue/shared": "3.2.1"
+        "@vue/compiler-dom": "3.2.4",
+        "@vue/shared": "3.2.4"
       }
     },
     "node_modules/@vue/devtools-api": {
@@ -2178,52 +2176,36 @@
       "integrity": "sha512-quBx4Jjpexo6KDiNUGFr/zF/2A4srKM9S9v2uHgMXSU//hjgq1eGzqkIFql8T9gfX5ZaVOUzYBP3jIdIR3PKIA=="
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.2.tgz",
-      "integrity": "sha512-IHjhtmrhK6dzacj/EnLQDWOaA3HuzzVk6w84qgV8EpS4uWGIJXiRalMRg6XvGW2ykJvIl3pLsF0aBFlTMRiLOA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.4.tgz",
+      "integrity": "sha512-ljWTR0hr8Tn09hM2tlmWxZzCBPlgGLnq/k8K8X6EcJhtV+C8OzFySnbWqMWataojbrQOocThwsC8awKthSl2uQ==",
       "dependencies": {
-        "@vue/shared": "3.2.2"
+        "@vue/shared": "3.2.4"
       }
-    },
-    "node_modules/@vue/reactivity/node_modules/@vue/shared": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.2.tgz",
-      "integrity": "sha512-dvYb318tk9uOzHtSaT3WII/HscQSIRzoCZ5GyxEb3JlkEXASpAUAQwKnvSe2CudnF8XHFRTB7VITWSnWNLZUtA=="
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.2.tgz",
-      "integrity": "sha512-/aUk1+GO/VPX0oVxhbzSWE1zrf3/wGCsO1ALNisVokYftKqfqLDjbJHE6mrI2hx3MiuwbHrWjJClkGUVTIOPEQ==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.4.tgz",
+      "integrity": "sha512-W6PtEOs8P8jKYPo3JwaMAozZQivxInUleGfNwI2pK1t8ZLZIxn4kAf7p4VF4jJdQB8SZBzpfWdLUc06j7IOmpQ==",
       "dependencies": {
-        "@vue/reactivity": "3.2.2",
-        "@vue/shared": "3.2.2"
+        "@vue/reactivity": "3.2.4",
+        "@vue/shared": "3.2.4"
       }
     },
-    "node_modules/@vue/runtime-core/node_modules/@vue/shared": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.2.tgz",
-      "integrity": "sha512-dvYb318tk9uOzHtSaT3WII/HscQSIRzoCZ5GyxEb3JlkEXASpAUAQwKnvSe2CudnF8XHFRTB7VITWSnWNLZUtA=="
-    },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.2.tgz",
-      "integrity": "sha512-1Le/NpCfawCOfePfJezvWUF+oCVLU8N+IHN4oFDOxRe6/PgHNJ+yT+YdxFifBfI+TIAoXI/9PsnqzmJZV+xsmw==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.4.tgz",
+      "integrity": "sha512-HcVtLyn2SGwsf6BFPwkvDPDOhOqkOKcfHDpBp5R1coX+qMsOFrY8lJnGXIY+JnxqFjND00E9+u+lq5cs/W7ooA==",
       "dependencies": {
-        "@vue/runtime-core": "3.2.2",
-        "@vue/shared": "3.2.2",
+        "@vue/runtime-core": "3.2.4",
+        "@vue/shared": "3.2.4",
         "csstype": "^2.6.8"
       }
     },
-    "node_modules/@vue/runtime-dom/node_modules/@vue/shared": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.2.tgz",
-      "integrity": "sha512-dvYb318tk9uOzHtSaT3WII/HscQSIRzoCZ5GyxEb3JlkEXASpAUAQwKnvSe2CudnF8XHFRTB7VITWSnWNLZUtA=="
-    },
     "node_modules/@vue/shared": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.1.tgz",
-      "integrity": "sha512-INN92dVBNgd0TW9BqfQQKx/HWGCHhUUbAV5EZ5FgSCiEdwuZsJbGt1mdnaD9IxGhpiyOjP2ClxGG8SFp7ELcWg==",
-      "dev": true
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.4.tgz",
+      "integrity": "sha512-j2j1MRmjalVKr3YBTxl/BClSIc8UQ8NnPpLYclxerK65JIowI4O7n8O8lElveEtEoHxy1d7BelPUDI0Q4bumqg=="
     },
     "node_modules/acorn": {
       "version": "7.4.1",
@@ -2442,16 +2424,16 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.16.7",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.7.tgz",
-      "integrity": "sha512-7I4qVwqZltJ7j37wObBe3SoTz+nS8APaNcrBOlgoirb6/HbEU2XxW/LpUDTCngM6iauwFqmRTuOMfyKnFGY5JA==",
+      "version": "4.16.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.8.tgz",
+      "integrity": "sha512-sc2m9ohR/49sWEbPj14ZSSZqp+kbi16aLao42Hmn3Z8FpjuMaq2xCA2l4zl9ITfyzvnvyE0hcg62YkIGKxgaNQ==",
       "dev": true,
       "dependencies": {
-        "caniuse-lite": "^1.0.30001248",
-        "colorette": "^1.2.2",
-        "electron-to-chromium": "^1.3.793",
+        "caniuse-lite": "^1.0.30001251",
+        "colorette": "^1.3.0",
+        "electron-to-chromium": "^1.3.811",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.73"
+        "node-releases": "^1.1.75"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2506,9 +2488,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001249",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001249.tgz",
-      "integrity": "sha512-vcX4U8lwVXPdqzPWi6cAJ3FnQaqXbBqy/GZseKNQzRj37J7qZdGcBtxq/QLFNLLlfsoXLUdHw8Iwenri86Tagw==",
+      "version": "1.0.30001251",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
+      "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -2627,9 +2609,9 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.16.1",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.16.1.tgz",
-      "integrity": "sha512-NHXQXvRbd4nxp9TEmooTJLUf94ySUG6+DSsscBpTftN1lQLQ4LjnWvc7AoIo4UjDsFF3hB8Uh5LLCRRdaiT5MQ==",
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.16.2.tgz",
+      "integrity": "sha512-4lUshXtBXsdmp8cDWh6KKiHUg40AjiuPD3bOWkNVsr1xkAhpUqCjaZ8lB1bKx9Gb5fXcbRbFJ4f4qpRIRTuJqQ==",
       "dev": true,
       "dependencies": {
         "browserslist": "^4.16.7",
@@ -2759,9 +2741,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.802",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.802.tgz",
-      "integrity": "sha512-dXB0SGSypfm3iEDxrb5n/IVKeX4uuTnFHdve7v+yKJqNpEP0D4mjFJ8e1znmSR+OOVlVC+kDO6f2kAkTFXvJBg==",
+      "version": "1.3.814",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.814.tgz",
+      "integrity": "sha512-0mH03cyjh6OzMlmjauGg0TLd87ErIJqWiYxMcOLKf5w6p0YEOl7DJAj7BDlXEFmCguY5CQaKVOiMjAMODO2XDw==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -2794,9 +2776,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.12.19",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.19.tgz",
-      "integrity": "sha512-5NuT1G6THW7l3fsSCDkcPepn24R0XtyPjKoqKHD8LfhqMXzCdz0mrS9HgO6hIhzVT7zt0T+JGbzCqF5AH8hS9w==",
+      "version": "0.12.22",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.22.tgz",
+      "integrity": "sha512-yWCr9RoFehpqoe/+MwZXJpYOEIt7KOEvNnjIeMZpMSyQt+KCBASM3y7yViiN5dJRphf1wGdUz1+M4rTtWd/ulA==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -3148,9 +3130,9 @@
       "peer": true
     },
     "node_modules/fastq": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.1.tgz",
-      "integrity": "sha512-HOnr8Mc60eNYl1gzwp6r5RoUyAn5/glBolUzP/Ez6IFVPMPirxn/9phgL6zhOtaTy7ISwPvQ+wT+hfcRZh/bzw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.12.0.tgz",
+      "integrity": "sha512-VNX0QkHK3RsXVKr9KrlUv/FoTa0NdbYoHHl7uXHv2rzyHSlxjdNAKug2twd9luJxpcyNeAgf5iPPMutJO67Dfg==",
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
@@ -3321,9 +3303,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.10.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.10.0.tgz",
-      "integrity": "sha512-piHC3blgLGFjvOuMmWZX60f+na1lXFDhQXBf1UYp2fXPXqvEUbOhNwi6BsQ0bQishwedgnjkwv1d9zKf+MWw3g==",
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
+      "integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -3471,9 +3453,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
-      "integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
+      "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
@@ -3644,15 +3626,18 @@
       }
     },
     "node_modules/jsonc-eslint-parser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-1.1.0.tgz",
-      "integrity": "sha512-FA3oS+8V0Mz4vv19YpY4TuZZi2ecR0RHTua9SjbCYb4+e35MWKIi7jn17zdGi6jxE7Cv7Vk61ml376MmMENieA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-1.2.0.tgz",
+      "integrity": "sha512-+vnjPNITAoDX2G9/IWV5vo234gQM3Gz40VuLIr74mc86f8UIKJ9blre+HnX2pHXejxolevV2a+BpaC0nhTq8yA==",
       "dev": true,
       "dependencies": {
-        "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.0.0",
+        "eslint-utils": "^2.1.0 || ^3.0.0",
+        "eslint-visitor-keys": "^1.3.0 || ^2.1.0 || ^3.0.0",
         "espree": "^6.0.0 || ^7.2.0",
         "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/jsonfile": {
@@ -3843,9 +3828,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.1.23",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
       "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -3862,9 +3847,9 @@
       "peer": true
     },
     "node_modules/node-releases": {
-      "version": "1.1.74",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.74.tgz",
-      "integrity": "sha512-caJBVempXZPepZoZAPCWRTNxYQ+xtG/KAi4ozTA5A+nJ7IU+kLQCbqaUjb5Rwy14M9upBWiQ4NutcmW04LJSRw==",
+      "version": "1.1.75",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
+      "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
       "dev": true
     },
     "node_modules/normalize-path": {
@@ -3986,18 +3971,18 @@
       }
     },
     "node_modules/pinia": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.0.0-rc.4.tgz",
-      "integrity": "sha512-I43V1TIFyDWT4UTi1CPLQXQZYXGQHQMKpDPI+oxC2fv0c+ej0fQBoKCn4WbfRWB+Vf5chhWM97GFLI+OWmUQEQ==",
+      "version": "2.0.0-rc.6",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.0.0-rc.6.tgz",
+      "integrity": "sha512-IqArmLmWJB5wZzELZfFF42bMaulo6cjMvL1wgUjWfmzaGCt1HYOAXN86s6HrdAueeEWj9Ov6lNNOHB1DFQxthw==",
       "dependencies": {
         "@vue/devtools-api": "^6.0.0-beta.15",
-        "vue-demi": "latest"
+        "vue-demi": "*"
       },
       "funding": {
         "url": "https://github.com/sponsors/posva"
       },
       "peerDependencies": {
-        "@vue/composition-api": "^1.1.0",
+        "@vue/composition-api": "^1.1.1",
         "typescript": "^4.3.5",
         "vue": "^2.6.14 || ^3.2.0"
       },
@@ -4011,9 +3996,9 @@
       }
     },
     "node_modules/pinia/node_modules/vue-demi": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.11.2.tgz",
-      "integrity": "sha512-J+X8Au6BhQdcej6LY4O986634hZLu55L0ewU2j8my7WIKlu8cK0dqmdUxqVHHMd/cMrKKZ9SywB/id6aLhwCtA==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.11.3.tgz",
+      "integrity": "sha512-DpM0TTMpclRZDV6AIacgg837zrim/C9Zn+2ztXBs9hsESJN9vC83ztjTe4KC4HgJuVle8YUjPp7HTwWtwOHfmg==",
       "hasInstallScript": true,
       "bin": {
         "vue-demi-fix": "bin/vue-demi-fix.js",
@@ -4027,7 +4012,7 @@
       },
       "peerDependencies": {
         "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0 || ^2.6.0"
+        "vue": "^3.0.0-0 || ^2.6.0"
       },
       "peerDependenciesMeta": {
         "@vue/composition-api": {
@@ -4440,9 +4425,9 @@
       "dev": true
     },
     "node_modules/sass": {
-      "version": "1.37.5",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.37.5.tgz",
-      "integrity": "sha512-Cx3ewxz9QB/ErnVIiWg2cH0kiYZ0FPvheDTVC6BsiEGBTZKKZJ1Gq5Kq6jy3PKtL6+EJ8NIoaBW/RSd2R6cZOA==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.38.0.tgz",
+      "integrity": "sha512-WBccZeMigAGKoI+NgD7Adh0ab1HUq+6BmyBUEaGxtErbUtWUevEbdgo5EZiJQofLUGcKtlNaO2IdN73AHEua5g==",
       "dev": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0"
@@ -4944,13 +4929,13 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.2.tgz",
-      "integrity": "sha512-D/LuzAV30CgNJYGyNheE/VUs5N4toL2IgmS6c9qeOxvyh0xyn4exyRqizpXIrsvfx34zG9x5gCI2tdRHCGvF9w==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.4.tgz",
+      "integrity": "sha512-rNCFmoewm8IwmTK0nj3ysKq53iRpNEFKoBJ4inar6tIh7Oj7juubS39RI8UI+VE7x+Cs2z6PBsadtZu7z2qppg==",
       "dependencies": {
-        "@vue/compiler-dom": "3.2.2",
-        "@vue/runtime-dom": "3.2.2",
-        "@vue/shared": "3.2.2"
+        "@vue/compiler-dom": "3.2.4",
+        "@vue/runtime-dom": "3.2.4",
+        "@vue/shared": "3.2.4"
       }
     },
     "node_modules/vue-i18n": {
@@ -4980,32 +4965,6 @@
       "peerDependencies": {
         "vue": "^3.0.0"
       }
-    },
-    "node_modules/vue/node_modules/@vue/compiler-core": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.2.tgz",
-      "integrity": "sha512-QhCI0ZU5nAR0LMcLgzW3v75374tIrHGp8XG5CzJS7Nsy+iuignbE4MZ2XJfh5TGIrtpuzfWA4eTIfukZf/cRdg==",
-      "dependencies": {
-        "@babel/parser": "^7.12.0",
-        "@babel/types": "^7.12.0",
-        "@vue/shared": "3.2.2",
-        "estree-walker": "^2.0.1",
-        "source-map": "^0.6.1"
-      }
-    },
-    "node_modules/vue/node_modules/@vue/compiler-dom": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.2.tgz",
-      "integrity": "sha512-ggcc+NV/ENIE0Uc3TxVE/sKrhYVpLepMAAmEiQ047332mbKOvUkowz4TTFZ+YkgOIuBOPP0XpCxmCMg7p874mA==",
-      "dependencies": {
-        "@vue/compiler-core": "3.2.2",
-        "@vue/shared": "3.2.2"
-      }
-    },
-    "node_modules/vue/node_modules/@vue/shared": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.2.tgz",
-      "integrity": "sha512-dvYb318tk9uOzHtSaT3WII/HscQSIRzoCZ5GyxEb3JlkEXASpAUAQwKnvSe2CudnF8XHFRTB7VITWSnWNLZUtA=="
     },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",
@@ -5051,28 +5010,28 @@
       }
     },
     "node_modules/workbox-background-sync": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-6.2.3.tgz",
-      "integrity": "sha512-mZNTujx5rr0aUIrGWuAcRTMuSol/JQ4FKUggKEuby6WerqOur8HSXZDjs++3Yx2YPCVOWqa4b1iqgM7bhFKHpA==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-6.2.4.tgz",
+      "integrity": "sha512-uoGgm1PZU6THRzXKlMEntrdA4Xkp6SCfxI7re4heN+yGrtAZq6zMKYhZmsdeW+YGnXS3y5xj7WV03b5TDgLh6A==",
       "dev": true,
       "dependencies": {
         "idb": "^6.0.0",
-        "workbox-core": "6.2.3"
+        "workbox-core": "6.2.4"
       }
     },
     "node_modules/workbox-broadcast-update": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-6.2.3.tgz",
-      "integrity": "sha512-nHktaFdA0En8+Z0yOE2bG7hRdUuM+vIsnjqe//PTonfI9RWuajYqAV80drYTlizpfd/2tVOZ37jbnmbE81M+eA==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-6.2.4.tgz",
+      "integrity": "sha512-0EpML2lbxNkiZUoap4BJDA0Hfz36MhtUd/rRhFvF6YWoRbTQ8tc6tMaRgM1EBIUmIN2OX9qQlkqe5SGGt4lfXQ==",
       "dev": true,
       "dependencies": {
-        "workbox-core": "6.2.3"
+        "workbox-core": "6.2.4"
       }
     },
     "node_modules/workbox-build": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-6.2.3.tgz",
-      "integrity": "sha512-cj/QBjB5UwnZnyHz1vUSr0GuwN6vO0rW4WCzvIrM6OAab5hb+yyPaoSpb/IQTHz0nw9bSv9X+ZTmC80tH6Nk2Q==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-6.2.4.tgz",
+      "integrity": "sha512-01ZbY1BHi+yYvu4yDGZBw9xm1bWyZW0QGWPxiksvSPAsNH/z/NwgtWW14YEroFyG98mmXb7pufWlwl40zE1KTw==",
       "dev": true,
       "dependencies": {
         "@apideck/better-ajv-errors": "^0.2.4",
@@ -5098,21 +5057,21 @@
         "strip-comments": "^2.0.1",
         "tempy": "^0.6.0",
         "upath": "^1.2.0",
-        "workbox-background-sync": "6.2.3",
-        "workbox-broadcast-update": "6.2.3",
-        "workbox-cacheable-response": "6.2.3",
-        "workbox-core": "6.2.3",
-        "workbox-expiration": "6.2.3",
-        "workbox-google-analytics": "6.2.3",
-        "workbox-navigation-preload": "6.2.3",
-        "workbox-precaching": "6.2.3",
-        "workbox-range-requests": "6.2.3",
-        "workbox-recipes": "6.2.3",
-        "workbox-routing": "6.2.3",
-        "workbox-strategies": "6.2.3",
-        "workbox-streams": "6.2.3",
-        "workbox-sw": "6.2.3",
-        "workbox-window": "6.2.3"
+        "workbox-background-sync": "6.2.4",
+        "workbox-broadcast-update": "6.2.4",
+        "workbox-cacheable-response": "6.2.4",
+        "workbox-core": "6.2.4",
+        "workbox-expiration": "6.2.4",
+        "workbox-google-analytics": "6.2.4",
+        "workbox-navigation-preload": "6.2.4",
+        "workbox-precaching": "6.2.4",
+        "workbox-range-requests": "6.2.4",
+        "workbox-recipes": "6.2.4",
+        "workbox-routing": "6.2.4",
+        "workbox-strategies": "6.2.4",
+        "workbox-streams": "6.2.4",
+        "workbox-sw": "6.2.4",
+        "workbox-window": "6.2.4"
       },
       "engines": {
         "node": ">=10.0.0"
@@ -5170,127 +5129,127 @@
       }
     },
     "node_modules/workbox-cacheable-response": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-6.2.3.tgz",
-      "integrity": "sha512-YKBJIynCCDbS9XIBbf2Os83I7ptZKpIk74GpjHydDjHdSGle5kwO5H5/iSTFp1osocPRIgQ0OUMna0W6ufqOGg==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-6.2.4.tgz",
+      "integrity": "sha512-KZSzAOmgWsrk15Wu+geCUSGLIyyzHaORKjH5JnR6qcVZAsm0JXUu2m2OZGqjQ+/eyQwrGdXXqAMW+4wQvTXccg==",
       "dev": true,
       "dependencies": {
-        "workbox-core": "6.2.3"
+        "workbox-core": "6.2.4"
       }
     },
     "node_modules/workbox-core": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-6.2.3.tgz",
-      "integrity": "sha512-5XJKMQRs/QJVjyFX2IP6uaj9/JYo7f8uPPe1EG77Kc43nj232EbV0iL2v32k5xuGD8aGKtFCJz9/IMJDn19iwA==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-6.2.4.tgz",
+      "integrity": "sha512-Nu8X4R4Is3g8uzEJ6qwbW2CGVpzntW/cSf8OfsQGIKQR0nt84FAKzP2cLDaNLp3L/iV9TuhZgCTZzkMiap5/OQ==",
       "dev": true
     },
     "node_modules/workbox-expiration": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-6.2.3.tgz",
-      "integrity": "sha512-T+vPm9HXKrVvpCtS1T0jKbqItDjaSQyTrhEMvEPPLmQGlTS2AwmevSoFzkFzpx7rIr0tA/KhCdhzwRrnrMqx7A==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-6.2.4.tgz",
+      "integrity": "sha512-EdOBLunrE3+Ff50y7AYDbiwtiLDvB+oEIkL1Wd9G5d176YVqFfgPfMRzJQ7fN+Yy2NfmsFME0Bw+dQruYekWsQ==",
       "dev": true,
       "dependencies": {
         "idb": "^6.0.0",
-        "workbox-core": "6.2.3"
+        "workbox-core": "6.2.4"
       }
     },
     "node_modules/workbox-google-analytics": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-6.2.3.tgz",
-      "integrity": "sha512-NBD1WPENPDg7wD+xqSeF3I/LaDR0AMJEpfuHeRLhGjeo1Q3NtpJLyGAaVN0Dh6tWXNXmkCsfugD2Q2ODrbsoxQ==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-6.2.4.tgz",
+      "integrity": "sha512-+PWmTouoGGcDupaxM193F2NmgrF597Pyt9eHIDxfed+x+JSSeUkETlbAKwB8rnBHkAjs8JQcvStEP/IpueNKpQ==",
       "dev": true,
       "dependencies": {
-        "workbox-background-sync": "6.2.3",
-        "workbox-core": "6.2.3",
-        "workbox-routing": "6.2.3",
-        "workbox-strategies": "6.2.3"
+        "workbox-background-sync": "6.2.4",
+        "workbox-core": "6.2.4",
+        "workbox-routing": "6.2.4",
+        "workbox-strategies": "6.2.4"
       }
     },
     "node_modules/workbox-navigation-preload": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-6.2.3.tgz",
-      "integrity": "sha512-73uS5cxDbz+aU6fSN5Luot0VCvbPbJJJDEsvEYHwQu7IJEhDjrKjFBNQvmY5HxQ4CCCvlC8jdIQYaG5m/hQCHg==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-6.2.4.tgz",
+      "integrity": "sha512-y2dOSsaSdEimqhCmBIFR6kBp+GZbtNtWCBaMFwfKxTAul2uyllKcTKBHnZ9IzxULue6o6voV+I2U8Y8tO8n+eA==",
       "dev": true,
       "dependencies": {
-        "workbox-core": "6.2.3"
+        "workbox-core": "6.2.4"
       }
     },
     "node_modules/workbox-precaching": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-6.2.3.tgz",
-      "integrity": "sha512-E63S7124pplcQcDEC9nc5GaTF+d588KKZQW8+r70oSZYmGTqgsCIvjAmHJUQfjo+ga6MaeNurt/DtM/HEvtVEQ==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-6.2.4.tgz",
+      "integrity": "sha512-7POznbVc8EG/mkbXzeb94x3B1VJruPgXvXFgS0NJ3GRugkO4ULs/DpIIb+ycs7uJIKY9EzLS7VXvElr3rMSozQ==",
       "dev": true,
       "dependencies": {
-        "workbox-core": "6.2.3",
-        "workbox-routing": "6.2.3",
-        "workbox-strategies": "6.2.3"
+        "workbox-core": "6.2.4",
+        "workbox-routing": "6.2.4",
+        "workbox-strategies": "6.2.4"
       }
     },
     "node_modules/workbox-range-requests": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-6.2.3.tgz",
-      "integrity": "sha512-tWkq2NTOBrYXjUdke0x2SsnZvF8gH9+FEgCPe7toCwiasq/mgXfyqf3aejuOMLO4bRR1pCQym2Ebx+cBUceFNA==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-6.2.4.tgz",
+      "integrity": "sha512-q4jjTXD1QOKbrHnzV3nxdZtIpOiVoIP5QyVmjuJrybVnAZurtyKcqirTQcAcT/zlTvgwm07zcTTk9o/zIB6DmA==",
       "dev": true,
       "dependencies": {
-        "workbox-core": "6.2.3"
+        "workbox-core": "6.2.4"
       }
     },
     "node_modules/workbox-recipes": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/workbox-recipes/-/workbox-recipes-6.2.3.tgz",
-      "integrity": "sha512-IvdMyww/RFXB3wNuCBt0J7Qp34w6vxc/vqcBWceY0FP7LAn+NJ8Vz6gpNIPr6WbApmiSFViNTMwIFi2HTNlNYA==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/workbox-recipes/-/workbox-recipes-6.2.4.tgz",
+      "integrity": "sha512-z7oECGrt940dw1Bv0xIDJEXY1xARiaxsIedeJOutZFkbgaC/yWG61VTr/hmkeJ8Nx6jnY6W7Rc0iOUvg4sePag==",
       "dev": true,
       "dependencies": {
-        "workbox-cacheable-response": "6.2.3",
-        "workbox-core": "6.2.3",
-        "workbox-expiration": "6.2.3",
-        "workbox-precaching": "6.2.3",
-        "workbox-routing": "6.2.3",
-        "workbox-strategies": "6.2.3"
+        "workbox-cacheable-response": "6.2.4",
+        "workbox-core": "6.2.4",
+        "workbox-expiration": "6.2.4",
+        "workbox-precaching": "6.2.4",
+        "workbox-routing": "6.2.4",
+        "workbox-strategies": "6.2.4"
       }
     },
     "node_modules/workbox-routing": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-6.2.3.tgz",
-      "integrity": "sha512-/uvxMbHOPskFM15fW38xdbkMW8NV6tLCVIBB18eESZZcC0SNIdsPKN8u2fAc4HgchnQZ919DYktb2yKsb2tkww==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-6.2.4.tgz",
+      "integrity": "sha512-jHnOmpeH4MOWR4eXv6l608npD2y6IFv7yFJ1bT9/RbB8wq2vXHXJQ0ExTZRTWGbVltSG22wEU+MQ8VebDDwDeg==",
       "dev": true,
       "dependencies": {
-        "workbox-core": "6.2.3"
+        "workbox-core": "6.2.4"
       }
     },
     "node_modules/workbox-strategies": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-6.2.3.tgz",
-      "integrity": "sha512-bVtNToqtwNn+L4lkDGxFMrTUXgFqeRMPpjeQgZTtKJJPuXP1f4CTir14mYOOgA9j/hdXtyoALo2DHgv7tZjfZQ==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-6.2.4.tgz",
+      "integrity": "sha512-DKgGC3ruceDuu2o+Ae5qmJy0p0q21mFP+RrkdqKrjyf2u8cJvvtvt1eIt4nevKc5BESiKxmhC2h+TZpOSzUDvA==",
       "dev": true,
       "dependencies": {
-        "workbox-core": "6.2.3"
+        "workbox-core": "6.2.4"
       }
     },
     "node_modules/workbox-streams": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-6.2.3.tgz",
-      "integrity": "sha512-sX9UKid8d60E5QwhRfXdYZMAEYL+2RHSUCaprGMqGHiWjStsEdNchM1mWrUZ+YNAWGMZrOC927hDFre/OcBEjQ==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-6.2.4.tgz",
+      "integrity": "sha512-yG6zV7S2NmYT6koyb7/DoPsyUAat9kD+rOmjP2SbBCtJdLu6ZIi1lgN4/rOkxEby/+Xb4OE4RmCSIZdMyjEmhQ==",
       "dev": true,
       "dependencies": {
-        "workbox-core": "6.2.3",
-        "workbox-routing": "6.2.3"
+        "workbox-core": "6.2.4",
+        "workbox-routing": "6.2.4"
       }
     },
     "node_modules/workbox-sw": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-6.2.3.tgz",
-      "integrity": "sha512-deC2RLx6E1JfwapfSAmwnVyWAtQOM4gkiMVohKNxVBgD62WmNao3aGR5GxUcDGmm3vzCz7nKqIS8ShSPg8nEqQ==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-6.2.4.tgz",
+      "integrity": "sha512-OlWLHNNM+j44sN2OaVXnVcf2wwhJUzcHlXrTrbWDu1JWnrQJ/rLicdc/sbxkZoyE0EbQm7Xr1BXcOjsB7PNlXQ==",
       "dev": true
     },
     "node_modules/workbox-window": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-6.2.3.tgz",
-      "integrity": "sha512-PeHeB8GrffEhCB3Pn+S1op/AoEgECOvrYlkAZ8NLzsDOBmFoEoOjjhyg5BQ6kUbuZVE93fZ1zyR/lw4P9dLrIA==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-6.2.4.tgz",
+      "integrity": "sha512-9jD6THkwGEASj1YP56ZBHYJ147733FoGpJlMamYk38k/EBFE75oc6K3Vs2tGOBx5ZGq54+mHSStnlrtFG3IiOg==",
       "dev": true,
       "dependencies": {
         "@types/trusted-types": "^2.0.2",
-        "workbox-core": "6.2.3"
+        "workbox-core": "6.2.4"
       }
     },
     "node_modules/wrappy": {
@@ -6814,9 +6773,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.4.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.13.tgz",
-      "integrity": "sha512-bLL69sKtd25w7p1nvg9pigE4gtKVpGTPojBFLMkGHXuUgap2sLqQt2qUnqmVCDfzGUL0DRNZP+1prIZJbMeAXg==",
+      "version": "16.7.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.1.tgz",
+      "integrity": "sha512-ncRdc45SoYJ2H4eWU9ReDfp3vtFqDYhjOsKlFFUDEn8V1Bgr2RjYal8YT5byfadWIRluhPFU6JiDOl0H6Sl87A==",
       "dev": true
     },
     "@types/resolve": {
@@ -6842,41 +6801,39 @@
       "requires": {}
     },
     "@vue/compiler-core": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.1.tgz",
-      "integrity": "sha512-UEJf2ZGww5wGVdrWIXIZo04KdJFGPmI2bHRUsBZ3AdyCAqJ5ykRXKOBn1OR1hvA2YzimudOEyHM+DpbBv91Kww==",
-      "dev": true,
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.4.tgz",
+      "integrity": "sha512-c8NuQq7mUXXxA4iqD5VUKpyVeklK53+DMbojYMyZ0VPPrb0BUWrZWFiqSDT+MFDv0f6Hv3QuLiHWb1BWMXBbrw==",
       "requires": {
         "@babel/parser": "^7.12.0",
         "@babel/types": "^7.12.0",
-        "@vue/shared": "3.2.1",
+        "@vue/shared": "3.2.4",
         "estree-walker": "^2.0.1",
         "source-map": "^0.6.1"
       }
     },
     "@vue/compiler-dom": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.1.tgz",
-      "integrity": "sha512-tXg8tkPb3j54zNfWqoao9T1JI41yWPz8TROzmif/QNNA46eq8/SRuRsBd36i47GWaz7mh+yg3vOJ87/YBjcMyQ==",
-      "dev": true,
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.4.tgz",
+      "integrity": "sha512-uj1nwO4794fw2YsYas5QT+FU/YGrXbS0Qk+1c7Kp1kV7idhZIghWLTjyvYibpGoseFbYLPd+sW2/noJG5H04EQ==",
       "requires": {
-        "@vue/compiler-core": "3.2.1",
-        "@vue/shared": "3.2.1"
+        "@vue/compiler-core": "3.2.4",
+        "@vue/shared": "3.2.4"
       }
     },
     "@vue/compiler-sfc": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.1.tgz",
-      "integrity": "sha512-fVLdme5RZVkBt+jxv2LCSRM72o4FX7BR2eu2FpjjEi1kEtUMKBDnjKwGWy7TyhTju0t0CocctyoM+G56vH7NpQ==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.4.tgz",
+      "integrity": "sha512-GM+ouDdDzhqgkLmBH4bgq4kiZxJQArSppJiZHWHIx9XRaefHLmc1LBNPmN8ivm4SVfi2i7M2t9k8ZnjsScgzPQ==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.13.9",
         "@babel/types": "^7.13.0",
         "@types/estree": "^0.0.48",
-        "@vue/compiler-core": "3.2.1",
-        "@vue/compiler-dom": "3.2.1",
-        "@vue/compiler-ssr": "3.2.1",
-        "@vue/shared": "3.2.1",
+        "@vue/compiler-core": "3.2.4",
+        "@vue/compiler-dom": "3.2.4",
+        "@vue/compiler-ssr": "3.2.4",
+        "@vue/shared": "3.2.4",
         "consolidate": "^0.16.0",
         "estree-walker": "^2.0.1",
         "hash-sum": "^2.0.0",
@@ -6890,13 +6847,13 @@
       }
     },
     "@vue/compiler-ssr": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.1.tgz",
-      "integrity": "sha512-6YAOtQunuEyYlVSjK1F7a7BXi7rxVfiTiJ0Ro7eq0q0MNCFV9Z+sN68lfa/E4ABVb0ledEY/Rt8kL23nwCoTCQ==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.4.tgz",
+      "integrity": "sha512-bKZuXu9/4XwsFHFWIKQK+5kN7mxIIWmMmT2L4VVek7cvY/vm3p4WTsXYDGZJy0htOTXvM2ifr6sflg012T0hsw==",
       "dev": true,
       "requires": {
-        "@vue/compiler-dom": "3.2.1",
-        "@vue/shared": "3.2.1"
+        "@vue/compiler-dom": "3.2.4",
+        "@vue/shared": "3.2.4"
       }
     },
     "@vue/devtools-api": {
@@ -6905,58 +6862,36 @@
       "integrity": "sha512-quBx4Jjpexo6KDiNUGFr/zF/2A4srKM9S9v2uHgMXSU//hjgq1eGzqkIFql8T9gfX5ZaVOUzYBP3jIdIR3PKIA=="
     },
     "@vue/reactivity": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.2.tgz",
-      "integrity": "sha512-IHjhtmrhK6dzacj/EnLQDWOaA3HuzzVk6w84qgV8EpS4uWGIJXiRalMRg6XvGW2ykJvIl3pLsF0aBFlTMRiLOA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.4.tgz",
+      "integrity": "sha512-ljWTR0hr8Tn09hM2tlmWxZzCBPlgGLnq/k8K8X6EcJhtV+C8OzFySnbWqMWataojbrQOocThwsC8awKthSl2uQ==",
       "requires": {
-        "@vue/shared": "3.2.2"
-      },
-      "dependencies": {
-        "@vue/shared": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.2.tgz",
-          "integrity": "sha512-dvYb318tk9uOzHtSaT3WII/HscQSIRzoCZ5GyxEb3JlkEXASpAUAQwKnvSe2CudnF8XHFRTB7VITWSnWNLZUtA=="
-        }
+        "@vue/shared": "3.2.4"
       }
     },
     "@vue/runtime-core": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.2.tgz",
-      "integrity": "sha512-/aUk1+GO/VPX0oVxhbzSWE1zrf3/wGCsO1ALNisVokYftKqfqLDjbJHE6mrI2hx3MiuwbHrWjJClkGUVTIOPEQ==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.4.tgz",
+      "integrity": "sha512-W6PtEOs8P8jKYPo3JwaMAozZQivxInUleGfNwI2pK1t8ZLZIxn4kAf7p4VF4jJdQB8SZBzpfWdLUc06j7IOmpQ==",
       "requires": {
-        "@vue/reactivity": "3.2.2",
-        "@vue/shared": "3.2.2"
-      },
-      "dependencies": {
-        "@vue/shared": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.2.tgz",
-          "integrity": "sha512-dvYb318tk9uOzHtSaT3WII/HscQSIRzoCZ5GyxEb3JlkEXASpAUAQwKnvSe2CudnF8XHFRTB7VITWSnWNLZUtA=="
-        }
+        "@vue/reactivity": "3.2.4",
+        "@vue/shared": "3.2.4"
       }
     },
     "@vue/runtime-dom": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.2.tgz",
-      "integrity": "sha512-1Le/NpCfawCOfePfJezvWUF+oCVLU8N+IHN4oFDOxRe6/PgHNJ+yT+YdxFifBfI+TIAoXI/9PsnqzmJZV+xsmw==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.4.tgz",
+      "integrity": "sha512-HcVtLyn2SGwsf6BFPwkvDPDOhOqkOKcfHDpBp5R1coX+qMsOFrY8lJnGXIY+JnxqFjND00E9+u+lq5cs/W7ooA==",
       "requires": {
-        "@vue/runtime-core": "3.2.2",
-        "@vue/shared": "3.2.2",
+        "@vue/runtime-core": "3.2.4",
+        "@vue/shared": "3.2.4",
         "csstype": "^2.6.8"
-      },
-      "dependencies": {
-        "@vue/shared": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.2.tgz",
-          "integrity": "sha512-dvYb318tk9uOzHtSaT3WII/HscQSIRzoCZ5GyxEb3JlkEXASpAUAQwKnvSe2CudnF8XHFRTB7VITWSnWNLZUtA=="
-        }
       }
     },
     "@vue/shared": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.1.tgz",
-      "integrity": "sha512-INN92dVBNgd0TW9BqfQQKx/HWGCHhUUbAV5EZ5FgSCiEdwuZsJbGt1mdnaD9IxGhpiyOjP2ClxGG8SFp7ELcWg==",
-      "dev": true
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.4.tgz",
+      "integrity": "sha512-j2j1MRmjalVKr3YBTxl/BClSIc8UQ8NnPpLYclxerK65JIowI4O7n8O8lElveEtEoHxy1d7BelPUDI0Q4bumqg=="
     },
     "acorn": {
       "version": "7.4.1",
@@ -7124,16 +7059,16 @@
       }
     },
     "browserslist": {
-      "version": "4.16.7",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.7.tgz",
-      "integrity": "sha512-7I4qVwqZltJ7j37wObBe3SoTz+nS8APaNcrBOlgoirb6/HbEU2XxW/LpUDTCngM6iauwFqmRTuOMfyKnFGY5JA==",
+      "version": "4.16.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.8.tgz",
+      "integrity": "sha512-sc2m9ohR/49sWEbPj14ZSSZqp+kbi16aLao42Hmn3Z8FpjuMaq2xCA2l4zl9ITfyzvnvyE0hcg62YkIGKxgaNQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001248",
-        "colorette": "^1.2.2",
-        "electron-to-chromium": "^1.3.793",
+        "caniuse-lite": "^1.0.30001251",
+        "colorette": "^1.3.0",
+        "electron-to-chromium": "^1.3.811",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.73"
+        "node-releases": "^1.1.75"
       }
     },
     "buffer-from": {
@@ -7166,9 +7101,9 @@
       "peer": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001249",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001249.tgz",
-      "integrity": "sha512-vcX4U8lwVXPdqzPWi6cAJ3FnQaqXbBqy/GZseKNQzRj37J7qZdGcBtxq/QLFNLLlfsoXLUdHw8Iwenri86Tagw==",
+      "version": "1.0.30001251",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
+      "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
       "dev": true
     },
     "chalk": {
@@ -7263,9 +7198,9 @@
       }
     },
     "core-js-compat": {
-      "version": "3.16.1",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.16.1.tgz",
-      "integrity": "sha512-NHXQXvRbd4nxp9TEmooTJLUf94ySUG6+DSsscBpTftN1lQLQ4LjnWvc7AoIo4UjDsFF3hB8Uh5LLCRRdaiT5MQ==",
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.16.2.tgz",
+      "integrity": "sha512-4lUshXtBXsdmp8cDWh6KKiHUg40AjiuPD3bOWkNVsr1xkAhpUqCjaZ8lB1bKx9Gb5fXcbRbFJ4f4qpRIRTuJqQ==",
       "dev": true,
       "requires": {
         "browserslist": "^4.16.7",
@@ -7357,9 +7292,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.802",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.802.tgz",
-      "integrity": "sha512-dXB0SGSypfm3iEDxrb5n/IVKeX4uuTnFHdve7v+yKJqNpEP0D4mjFJ8e1znmSR+OOVlVC+kDO6f2kAkTFXvJBg==",
+      "version": "1.3.814",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.814.tgz",
+      "integrity": "sha512-0mH03cyjh6OzMlmjauGg0TLd87ErIJqWiYxMcOLKf5w6p0YEOl7DJAj7BDlXEFmCguY5CQaKVOiMjAMODO2XDw==",
       "dev": true
     },
     "emoji-regex": {
@@ -7386,9 +7321,9 @@
       }
     },
     "esbuild": {
-      "version": "0.12.19",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.19.tgz",
-      "integrity": "sha512-5NuT1G6THW7l3fsSCDkcPepn24R0XtyPjKoqKHD8LfhqMXzCdz0mrS9HgO6hIhzVT7zt0T+JGbzCqF5AH8hS9w==",
+      "version": "0.12.22",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.22.tgz",
+      "integrity": "sha512-yWCr9RoFehpqoe/+MwZXJpYOEIt7KOEvNnjIeMZpMSyQt+KCBASM3y7yViiN5dJRphf1wGdUz1+M4rTtWd/ulA==",
       "dev": true
     },
     "escalade": {
@@ -7657,9 +7592,9 @@
       "peer": true
     },
     "fastq": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.1.tgz",
-      "integrity": "sha512-HOnr8Mc60eNYl1gzwp6r5RoUyAn5/glBolUzP/Ez6IFVPMPirxn/9phgL6zhOtaTy7ISwPvQ+wT+hfcRZh/bzw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.12.0.tgz",
+      "integrity": "sha512-VNX0QkHK3RsXVKr9KrlUv/FoTa0NdbYoHHl7uXHv2rzyHSlxjdNAKug2twd9luJxpcyNeAgf5iPPMutJO67Dfg==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -7796,9 +7731,9 @@
       }
     },
     "globals": {
-      "version": "13.10.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.10.0.tgz",
-      "integrity": "sha512-piHC3blgLGFjvOuMmWZX60f+na1lXFDhQXBf1UYp2fXPXqvEUbOhNwi6BsQ0bQishwedgnjkwv1d9zKf+MWw3g==",
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
+      "integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -7908,9 +7843,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
-      "integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
+      "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -8039,13 +7974,13 @@
       }
     },
     "jsonc-eslint-parser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-1.1.0.tgz",
-      "integrity": "sha512-FA3oS+8V0Mz4vv19YpY4TuZZi2ecR0RHTua9SjbCYb4+e35MWKIi7jn17zdGi6jxE7Cv7Vk61ml376MmMENieA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-1.2.0.tgz",
+      "integrity": "sha512-+vnjPNITAoDX2G9/IWV5vo234gQM3Gz40VuLIr74mc86f8UIKJ9blre+HnX2pHXejxolevV2a+BpaC0nhTq8yA==",
       "dev": true,
       "requires": {
-        "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.0.0",
+        "eslint-utils": "^2.1.0 || ^3.0.0",
+        "eslint-visitor-keys": "^1.3.0 || ^2.1.0 || ^3.0.0",
         "espree": "^6.0.0 || ^7.2.0",
         "semver": "^6.3.0"
       }
@@ -8215,9 +8150,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.1.23",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
       "dev": true
     },
     "natural-compare": {
@@ -8228,9 +8163,9 @@
       "peer": true
     },
     "node-releases": {
-      "version": "1.1.74",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.74.tgz",
-      "integrity": "sha512-caJBVempXZPepZoZAPCWRTNxYQ+xtG/KAi4ozTA5A+nJ7IU+kLQCbqaUjb5Rwy14M9upBWiQ4NutcmW04LJSRw==",
+      "version": "1.1.75",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
+      "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
       "dev": true
     },
     "normalize-path": {
@@ -8322,18 +8257,18 @@
       "dev": true
     },
     "pinia": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.0.0-rc.4.tgz",
-      "integrity": "sha512-I43V1TIFyDWT4UTi1CPLQXQZYXGQHQMKpDPI+oxC2fv0c+ej0fQBoKCn4WbfRWB+Vf5chhWM97GFLI+OWmUQEQ==",
+      "version": "2.0.0-rc.6",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.0.0-rc.6.tgz",
+      "integrity": "sha512-IqArmLmWJB5wZzELZfFF42bMaulo6cjMvL1wgUjWfmzaGCt1HYOAXN86s6HrdAueeEWj9Ov6lNNOHB1DFQxthw==",
       "requires": {
         "@vue/devtools-api": "^6.0.0-beta.15",
-        "vue-demi": "latest"
+        "vue-demi": "*"
       },
       "dependencies": {
         "vue-demi": {
-          "version": "0.11.2",
-          "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.11.2.tgz",
-          "integrity": "sha512-J+X8Au6BhQdcej6LY4O986634hZLu55L0ewU2j8my7WIKlu8cK0dqmdUxqVHHMd/cMrKKZ9SywB/id6aLhwCtA==",
+          "version": "0.11.3",
+          "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.11.3.tgz",
+          "integrity": "sha512-DpM0TTMpclRZDV6AIacgg837zrim/C9Zn+2ztXBs9hsESJN9vC83ztjTe4KC4HgJuVle8YUjPp7HTwWtwOHfmg==",
           "requires": {}
         }
       }
@@ -8617,9 +8552,9 @@
       "dev": true
     },
     "sass": {
-      "version": "1.37.5",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.37.5.tgz",
-      "integrity": "sha512-Cx3ewxz9QB/ErnVIiWg2cH0kiYZ0FPvheDTVC6BsiEGBTZKKZJ1Gq5Kq6jy3PKtL6+EJ8NIoaBW/RSd2R6cZOA==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.38.0.tgz",
+      "integrity": "sha512-WBccZeMigAGKoI+NgD7Adh0ab1HUq+6BmyBUEaGxtErbUtWUevEbdgo5EZiJQofLUGcKtlNaO2IdN73AHEua5g==",
       "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0"
@@ -8998,41 +8933,13 @@
       }
     },
     "vue": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.2.tgz",
-      "integrity": "sha512-D/LuzAV30CgNJYGyNheE/VUs5N4toL2IgmS6c9qeOxvyh0xyn4exyRqizpXIrsvfx34zG9x5gCI2tdRHCGvF9w==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.4.tgz",
+      "integrity": "sha512-rNCFmoewm8IwmTK0nj3ysKq53iRpNEFKoBJ4inar6tIh7Oj7juubS39RI8UI+VE7x+Cs2z6PBsadtZu7z2qppg==",
       "requires": {
-        "@vue/compiler-dom": "3.2.2",
-        "@vue/runtime-dom": "3.2.2",
-        "@vue/shared": "3.2.2"
-      },
-      "dependencies": {
-        "@vue/compiler-core": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.2.tgz",
-          "integrity": "sha512-QhCI0ZU5nAR0LMcLgzW3v75374tIrHGp8XG5CzJS7Nsy+iuignbE4MZ2XJfh5TGIrtpuzfWA4eTIfukZf/cRdg==",
-          "requires": {
-            "@babel/parser": "^7.12.0",
-            "@babel/types": "^7.12.0",
-            "@vue/shared": "3.2.2",
-            "estree-walker": "^2.0.1",
-            "source-map": "^0.6.1"
-          }
-        },
-        "@vue/compiler-dom": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.2.tgz",
-          "integrity": "sha512-ggcc+NV/ENIE0Uc3TxVE/sKrhYVpLepMAAmEiQ047332mbKOvUkowz4TTFZ+YkgOIuBOPP0XpCxmCMg7p874mA==",
-          "requires": {
-            "@vue/compiler-core": "3.2.2",
-            "@vue/shared": "3.2.2"
-          }
-        },
-        "@vue/shared": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.2.tgz",
-          "integrity": "sha512-dvYb318tk9uOzHtSaT3WII/HscQSIRzoCZ5GyxEb3JlkEXASpAUAQwKnvSe2CudnF8XHFRTB7VITWSnWNLZUtA=="
-        }
+        "@vue/compiler-dom": "3.2.4",
+        "@vue/runtime-dom": "3.2.4",
+        "@vue/shared": "3.2.4"
       }
     },
     "vue-i18n": {
@@ -9089,28 +8996,28 @@
       "peer": true
     },
     "workbox-background-sync": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-6.2.3.tgz",
-      "integrity": "sha512-mZNTujx5rr0aUIrGWuAcRTMuSol/JQ4FKUggKEuby6WerqOur8HSXZDjs++3Yx2YPCVOWqa4b1iqgM7bhFKHpA==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-6.2.4.tgz",
+      "integrity": "sha512-uoGgm1PZU6THRzXKlMEntrdA4Xkp6SCfxI7re4heN+yGrtAZq6zMKYhZmsdeW+YGnXS3y5xj7WV03b5TDgLh6A==",
       "dev": true,
       "requires": {
         "idb": "^6.0.0",
-        "workbox-core": "6.2.3"
+        "workbox-core": "6.2.4"
       }
     },
     "workbox-broadcast-update": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-6.2.3.tgz",
-      "integrity": "sha512-nHktaFdA0En8+Z0yOE2bG7hRdUuM+vIsnjqe//PTonfI9RWuajYqAV80drYTlizpfd/2tVOZ37jbnmbE81M+eA==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-6.2.4.tgz",
+      "integrity": "sha512-0EpML2lbxNkiZUoap4BJDA0Hfz36MhtUd/rRhFvF6YWoRbTQ8tc6tMaRgM1EBIUmIN2OX9qQlkqe5SGGt4lfXQ==",
       "dev": true,
       "requires": {
-        "workbox-core": "6.2.3"
+        "workbox-core": "6.2.4"
       }
     },
     "workbox-build": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-6.2.3.tgz",
-      "integrity": "sha512-cj/QBjB5UwnZnyHz1vUSr0GuwN6vO0rW4WCzvIrM6OAab5hb+yyPaoSpb/IQTHz0nw9bSv9X+ZTmC80tH6Nk2Q==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-6.2.4.tgz",
+      "integrity": "sha512-01ZbY1BHi+yYvu4yDGZBw9xm1bWyZW0QGWPxiksvSPAsNH/z/NwgtWW14YEroFyG98mmXb7pufWlwl40zE1KTw==",
       "dev": true,
       "requires": {
         "@apideck/better-ajv-errors": "^0.2.4",
@@ -9136,21 +9043,21 @@
         "strip-comments": "^2.0.1",
         "tempy": "^0.6.0",
         "upath": "^1.2.0",
-        "workbox-background-sync": "6.2.3",
-        "workbox-broadcast-update": "6.2.3",
-        "workbox-cacheable-response": "6.2.3",
-        "workbox-core": "6.2.3",
-        "workbox-expiration": "6.2.3",
-        "workbox-google-analytics": "6.2.3",
-        "workbox-navigation-preload": "6.2.3",
-        "workbox-precaching": "6.2.3",
-        "workbox-range-requests": "6.2.3",
-        "workbox-recipes": "6.2.3",
-        "workbox-routing": "6.2.3",
-        "workbox-strategies": "6.2.3",
-        "workbox-streams": "6.2.3",
-        "workbox-sw": "6.2.3",
-        "workbox-window": "6.2.3"
+        "workbox-background-sync": "6.2.4",
+        "workbox-broadcast-update": "6.2.4",
+        "workbox-cacheable-response": "6.2.4",
+        "workbox-core": "6.2.4",
+        "workbox-expiration": "6.2.4",
+        "workbox-google-analytics": "6.2.4",
+        "workbox-navigation-preload": "6.2.4",
+        "workbox-precaching": "6.2.4",
+        "workbox-range-requests": "6.2.4",
+        "workbox-recipes": "6.2.4",
+        "workbox-routing": "6.2.4",
+        "workbox-strategies": "6.2.4",
+        "workbox-streams": "6.2.4",
+        "workbox-sw": "6.2.4",
+        "workbox-window": "6.2.4"
       },
       "dependencies": {
         "@apideck/better-ajv-errors": {
@@ -9194,127 +9101,127 @@
       }
     },
     "workbox-cacheable-response": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-6.2.3.tgz",
-      "integrity": "sha512-YKBJIynCCDbS9XIBbf2Os83I7ptZKpIk74GpjHydDjHdSGle5kwO5H5/iSTFp1osocPRIgQ0OUMna0W6ufqOGg==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-6.2.4.tgz",
+      "integrity": "sha512-KZSzAOmgWsrk15Wu+geCUSGLIyyzHaORKjH5JnR6qcVZAsm0JXUu2m2OZGqjQ+/eyQwrGdXXqAMW+4wQvTXccg==",
       "dev": true,
       "requires": {
-        "workbox-core": "6.2.3"
+        "workbox-core": "6.2.4"
       }
     },
     "workbox-core": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-6.2.3.tgz",
-      "integrity": "sha512-5XJKMQRs/QJVjyFX2IP6uaj9/JYo7f8uPPe1EG77Kc43nj232EbV0iL2v32k5xuGD8aGKtFCJz9/IMJDn19iwA==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-6.2.4.tgz",
+      "integrity": "sha512-Nu8X4R4Is3g8uzEJ6qwbW2CGVpzntW/cSf8OfsQGIKQR0nt84FAKzP2cLDaNLp3L/iV9TuhZgCTZzkMiap5/OQ==",
       "dev": true
     },
     "workbox-expiration": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-6.2.3.tgz",
-      "integrity": "sha512-T+vPm9HXKrVvpCtS1T0jKbqItDjaSQyTrhEMvEPPLmQGlTS2AwmevSoFzkFzpx7rIr0tA/KhCdhzwRrnrMqx7A==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-6.2.4.tgz",
+      "integrity": "sha512-EdOBLunrE3+Ff50y7AYDbiwtiLDvB+oEIkL1Wd9G5d176YVqFfgPfMRzJQ7fN+Yy2NfmsFME0Bw+dQruYekWsQ==",
       "dev": true,
       "requires": {
         "idb": "^6.0.0",
-        "workbox-core": "6.2.3"
+        "workbox-core": "6.2.4"
       }
     },
     "workbox-google-analytics": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-6.2.3.tgz",
-      "integrity": "sha512-NBD1WPENPDg7wD+xqSeF3I/LaDR0AMJEpfuHeRLhGjeo1Q3NtpJLyGAaVN0Dh6tWXNXmkCsfugD2Q2ODrbsoxQ==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-6.2.4.tgz",
+      "integrity": "sha512-+PWmTouoGGcDupaxM193F2NmgrF597Pyt9eHIDxfed+x+JSSeUkETlbAKwB8rnBHkAjs8JQcvStEP/IpueNKpQ==",
       "dev": true,
       "requires": {
-        "workbox-background-sync": "6.2.3",
-        "workbox-core": "6.2.3",
-        "workbox-routing": "6.2.3",
-        "workbox-strategies": "6.2.3"
+        "workbox-background-sync": "6.2.4",
+        "workbox-core": "6.2.4",
+        "workbox-routing": "6.2.4",
+        "workbox-strategies": "6.2.4"
       }
     },
     "workbox-navigation-preload": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-6.2.3.tgz",
-      "integrity": "sha512-73uS5cxDbz+aU6fSN5Luot0VCvbPbJJJDEsvEYHwQu7IJEhDjrKjFBNQvmY5HxQ4CCCvlC8jdIQYaG5m/hQCHg==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-6.2.4.tgz",
+      "integrity": "sha512-y2dOSsaSdEimqhCmBIFR6kBp+GZbtNtWCBaMFwfKxTAul2uyllKcTKBHnZ9IzxULue6o6voV+I2U8Y8tO8n+eA==",
       "dev": true,
       "requires": {
-        "workbox-core": "6.2.3"
+        "workbox-core": "6.2.4"
       }
     },
     "workbox-precaching": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-6.2.3.tgz",
-      "integrity": "sha512-E63S7124pplcQcDEC9nc5GaTF+d588KKZQW8+r70oSZYmGTqgsCIvjAmHJUQfjo+ga6MaeNurt/DtM/HEvtVEQ==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-6.2.4.tgz",
+      "integrity": "sha512-7POznbVc8EG/mkbXzeb94x3B1VJruPgXvXFgS0NJ3GRugkO4ULs/DpIIb+ycs7uJIKY9EzLS7VXvElr3rMSozQ==",
       "dev": true,
       "requires": {
-        "workbox-core": "6.2.3",
-        "workbox-routing": "6.2.3",
-        "workbox-strategies": "6.2.3"
+        "workbox-core": "6.2.4",
+        "workbox-routing": "6.2.4",
+        "workbox-strategies": "6.2.4"
       }
     },
     "workbox-range-requests": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-6.2.3.tgz",
-      "integrity": "sha512-tWkq2NTOBrYXjUdke0x2SsnZvF8gH9+FEgCPe7toCwiasq/mgXfyqf3aejuOMLO4bRR1pCQym2Ebx+cBUceFNA==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-6.2.4.tgz",
+      "integrity": "sha512-q4jjTXD1QOKbrHnzV3nxdZtIpOiVoIP5QyVmjuJrybVnAZurtyKcqirTQcAcT/zlTvgwm07zcTTk9o/zIB6DmA==",
       "dev": true,
       "requires": {
-        "workbox-core": "6.2.3"
+        "workbox-core": "6.2.4"
       }
     },
     "workbox-recipes": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/workbox-recipes/-/workbox-recipes-6.2.3.tgz",
-      "integrity": "sha512-IvdMyww/RFXB3wNuCBt0J7Qp34w6vxc/vqcBWceY0FP7LAn+NJ8Vz6gpNIPr6WbApmiSFViNTMwIFi2HTNlNYA==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/workbox-recipes/-/workbox-recipes-6.2.4.tgz",
+      "integrity": "sha512-z7oECGrt940dw1Bv0xIDJEXY1xARiaxsIedeJOutZFkbgaC/yWG61VTr/hmkeJ8Nx6jnY6W7Rc0iOUvg4sePag==",
       "dev": true,
       "requires": {
-        "workbox-cacheable-response": "6.2.3",
-        "workbox-core": "6.2.3",
-        "workbox-expiration": "6.2.3",
-        "workbox-precaching": "6.2.3",
-        "workbox-routing": "6.2.3",
-        "workbox-strategies": "6.2.3"
+        "workbox-cacheable-response": "6.2.4",
+        "workbox-core": "6.2.4",
+        "workbox-expiration": "6.2.4",
+        "workbox-precaching": "6.2.4",
+        "workbox-routing": "6.2.4",
+        "workbox-strategies": "6.2.4"
       }
     },
     "workbox-routing": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-6.2.3.tgz",
-      "integrity": "sha512-/uvxMbHOPskFM15fW38xdbkMW8NV6tLCVIBB18eESZZcC0SNIdsPKN8u2fAc4HgchnQZ919DYktb2yKsb2tkww==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-6.2.4.tgz",
+      "integrity": "sha512-jHnOmpeH4MOWR4eXv6l608npD2y6IFv7yFJ1bT9/RbB8wq2vXHXJQ0ExTZRTWGbVltSG22wEU+MQ8VebDDwDeg==",
       "dev": true,
       "requires": {
-        "workbox-core": "6.2.3"
+        "workbox-core": "6.2.4"
       }
     },
     "workbox-strategies": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-6.2.3.tgz",
-      "integrity": "sha512-bVtNToqtwNn+L4lkDGxFMrTUXgFqeRMPpjeQgZTtKJJPuXP1f4CTir14mYOOgA9j/hdXtyoALo2DHgv7tZjfZQ==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-6.2.4.tgz",
+      "integrity": "sha512-DKgGC3ruceDuu2o+Ae5qmJy0p0q21mFP+RrkdqKrjyf2u8cJvvtvt1eIt4nevKc5BESiKxmhC2h+TZpOSzUDvA==",
       "dev": true,
       "requires": {
-        "workbox-core": "6.2.3"
+        "workbox-core": "6.2.4"
       }
     },
     "workbox-streams": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-6.2.3.tgz",
-      "integrity": "sha512-sX9UKid8d60E5QwhRfXdYZMAEYL+2RHSUCaprGMqGHiWjStsEdNchM1mWrUZ+YNAWGMZrOC927hDFre/OcBEjQ==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-6.2.4.tgz",
+      "integrity": "sha512-yG6zV7S2NmYT6koyb7/DoPsyUAat9kD+rOmjP2SbBCtJdLu6ZIi1lgN4/rOkxEby/+Xb4OE4RmCSIZdMyjEmhQ==",
       "dev": true,
       "requires": {
-        "workbox-core": "6.2.3",
-        "workbox-routing": "6.2.3"
+        "workbox-core": "6.2.4",
+        "workbox-routing": "6.2.4"
       }
     },
     "workbox-sw": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-6.2.3.tgz",
-      "integrity": "sha512-deC2RLx6E1JfwapfSAmwnVyWAtQOM4gkiMVohKNxVBgD62WmNao3aGR5GxUcDGmm3vzCz7nKqIS8ShSPg8nEqQ==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-6.2.4.tgz",
+      "integrity": "sha512-OlWLHNNM+j44sN2OaVXnVcf2wwhJUzcHlXrTrbWDu1JWnrQJ/rLicdc/sbxkZoyE0EbQm7Xr1BXcOjsB7PNlXQ==",
       "dev": true
     },
     "workbox-window": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-6.2.3.tgz",
-      "integrity": "sha512-PeHeB8GrffEhCB3Pn+S1op/AoEgECOvrYlkAZ8NLzsDOBmFoEoOjjhyg5BQ6kUbuZVE93fZ1zyR/lw4P9dLrIA==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-6.2.4.tgz",
+      "integrity": "sha512-9jD6THkwGEASj1YP56ZBHYJ147733FoGpJlMamYk38k/EBFE75oc6K3Vs2tGOBx5ZGq54+mHSStnlrtFG3IiOg==",
       "dev": true,
       "requires": {
         "@types/trusted-types": "^2.0.2",
-        "workbox-core": "6.2.3"
+        "workbox-core": "6.2.4"
       }
     },
     "wrappy": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,16 +12,16 @@
         "matercolors": "^2.2.10",
         "notyf": "^3.10.0",
         "pinia": "^2.0.0-beta.3",
-        "vue": "^3.0.5",
+        "vue": "^3.2.2",
         "vue-i18n": "^9.1.7",
         "vue-router": "^4.0.8"
       },
       "devDependencies": {
         "@intlify/vite-plugin-vue-i18n": "^2.4.0",
-        "@vitejs/plugin-vue": "^1.2.3",
+        "@vitejs/plugin-vue": "^1.4.0",
         "@vue/compiler-sfc": "^3.0.5",
         "sass": "^1.34.1",
-        "vite": "^2.3.7",
+        "vite": "^2.5.0",
         "vite-plugin-pwa": "^0.8.1"
       }
     },
@@ -2118,6 +2118,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.1.tgz",
       "integrity": "sha512-UEJf2ZGww5wGVdrWIXIZo04KdJFGPmI2bHRUsBZ3AdyCAqJ5ykRXKOBn1OR1hvA2YzimudOEyHM+DpbBv91Kww==",
+      "dev": true,
       "dependencies": {
         "@babel/parser": "^7.12.0",
         "@babel/types": "^7.12.0",
@@ -2130,6 +2131,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.1.tgz",
       "integrity": "sha512-tXg8tkPb3j54zNfWqoao9T1JI41yWPz8TROzmif/QNNA46eq8/SRuRsBd36i47GWaz7mh+yg3vOJ87/YBjcMyQ==",
+      "dev": true,
       "dependencies": {
         "@vue/compiler-core": "3.2.1",
         "@vue/shared": "3.2.1"
@@ -2176,36 +2178,52 @@
       "integrity": "sha512-quBx4Jjpexo6KDiNUGFr/zF/2A4srKM9S9v2uHgMXSU//hjgq1eGzqkIFql8T9gfX5ZaVOUzYBP3jIdIR3PKIA=="
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.1.tgz",
-      "integrity": "sha512-4Lja2KmyiKvuraDed6dXK2A6+r/7x7xGDA7vVR2Aqc8hQVu0+FWeVX+IBfiVOSpbZXFlHLNmCBFkbuWLQSlgxg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.2.tgz",
+      "integrity": "sha512-IHjhtmrhK6dzacj/EnLQDWOaA3HuzzVk6w84qgV8EpS4uWGIJXiRalMRg6XvGW2ykJvIl3pLsF0aBFlTMRiLOA==",
       "dependencies": {
-        "@vue/shared": "3.2.1"
+        "@vue/shared": "3.2.2"
       }
+    },
+    "node_modules/@vue/reactivity/node_modules/@vue/shared": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.2.tgz",
+      "integrity": "sha512-dvYb318tk9uOzHtSaT3WII/HscQSIRzoCZ5GyxEb3JlkEXASpAUAQwKnvSe2CudnF8XHFRTB7VITWSnWNLZUtA=="
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.1.tgz",
-      "integrity": "sha512-IsgelRM/5hYeRhz5+ECi66XvYDdjG2t4lARjHvCXw5s9Q4N6uIbjLMwtLzAWRxYf3/y258BrD+ehxAi943ScJg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.2.tgz",
+      "integrity": "sha512-/aUk1+GO/VPX0oVxhbzSWE1zrf3/wGCsO1ALNisVokYftKqfqLDjbJHE6mrI2hx3MiuwbHrWjJClkGUVTIOPEQ==",
       "dependencies": {
-        "@vue/reactivity": "3.2.1",
-        "@vue/shared": "3.2.1"
+        "@vue/reactivity": "3.2.2",
+        "@vue/shared": "3.2.2"
       }
     },
+    "node_modules/@vue/runtime-core/node_modules/@vue/shared": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.2.tgz",
+      "integrity": "sha512-dvYb318tk9uOzHtSaT3WII/HscQSIRzoCZ5GyxEb3JlkEXASpAUAQwKnvSe2CudnF8XHFRTB7VITWSnWNLZUtA=="
+    },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.1.tgz",
-      "integrity": "sha512-bUAHUSe49A5wYdHQ8wsLU1CMPXaG2fRuv2661mx/6Q9+20QxglT3ss8ZeL6AVRu16JNJMcdvTTsNpbnMbVc/lQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.2.tgz",
+      "integrity": "sha512-1Le/NpCfawCOfePfJezvWUF+oCVLU8N+IHN4oFDOxRe6/PgHNJ+yT+YdxFifBfI+TIAoXI/9PsnqzmJZV+xsmw==",
       "dependencies": {
-        "@vue/runtime-core": "3.2.1",
-        "@vue/shared": "3.2.1",
+        "@vue/runtime-core": "3.2.2",
+        "@vue/shared": "3.2.2",
         "csstype": "^2.6.8"
       }
+    },
+    "node_modules/@vue/runtime-dom/node_modules/@vue/shared": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.2.tgz",
+      "integrity": "sha512-dvYb318tk9uOzHtSaT3WII/HscQSIRzoCZ5GyxEb3JlkEXASpAUAQwKnvSe2CudnF8XHFRTB7VITWSnWNLZUtA=="
     },
     "node_modules/@vue/shared": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.1.tgz",
-      "integrity": "sha512-INN92dVBNgd0TW9BqfQQKx/HWGCHhUUbAV5EZ5FgSCiEdwuZsJbGt1mdnaD9IxGhpiyOjP2ClxGG8SFp7ELcWg=="
+      "integrity": "sha512-INN92dVBNgd0TW9BqfQQKx/HWGCHhUUbAV5EZ5FgSCiEdwuZsJbGt1mdnaD9IxGhpiyOjP2ClxGG8SFp7ELcWg==",
+      "dev": true
     },
     "node_modules/acorn": {
       "version": "7.4.1",
@@ -4886,12 +4904,12 @@
       "peer": true
     },
     "node_modules/vite": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.4.4.tgz",
-      "integrity": "sha512-m1wK6pFJKmaYA6AeZIUXyiAgUAAJzVXhIMYCdZUpCaFMGps0v0IlNJtbmPvkUhVEyautalajmnW5X6NboUPsnw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.5.0.tgz",
+      "integrity": "sha512-Dn4B+g54PJsMG5WCc4QeFy1ygMXRdTtFrUPegqfk4+vzVQcbF/DqqmI/1bxezArzbujBJg/67QeT5wz8edfJVQ==",
       "dev": true,
       "dependencies": {
-        "esbuild": "^0.12.8",
+        "esbuild": "^0.12.17",
         "postcss": "^8.3.6",
         "resolve": "^1.20.0",
         "rollup": "^2.38.5"
@@ -4900,7 +4918,7 @@
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=12.2.0"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
@@ -4926,13 +4944,13 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.1.tgz",
-      "integrity": "sha512-0jhXluF5mzTAK5bXw/8yq4McvsI8HwEWI4cnQwJeN8NYGRbwh9wwuE4FNv1Kej9pxBB5ajTNsWr0M6DPs5EJZg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.2.tgz",
+      "integrity": "sha512-D/LuzAV30CgNJYGyNheE/VUs5N4toL2IgmS6c9qeOxvyh0xyn4exyRqizpXIrsvfx34zG9x5gCI2tdRHCGvF9w==",
       "dependencies": {
-        "@vue/compiler-dom": "3.2.1",
-        "@vue/runtime-dom": "3.2.1",
-        "@vue/shared": "3.2.1"
+        "@vue/compiler-dom": "3.2.2",
+        "@vue/runtime-dom": "3.2.2",
+        "@vue/shared": "3.2.2"
       }
     },
     "node_modules/vue-i18n": {
@@ -4962,6 +4980,32 @@
       "peerDependencies": {
         "vue": "^3.0.0"
       }
+    },
+    "node_modules/vue/node_modules/@vue/compiler-core": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.2.tgz",
+      "integrity": "sha512-QhCI0ZU5nAR0LMcLgzW3v75374tIrHGp8XG5CzJS7Nsy+iuignbE4MZ2XJfh5TGIrtpuzfWA4eTIfukZf/cRdg==",
+      "dependencies": {
+        "@babel/parser": "^7.12.0",
+        "@babel/types": "^7.12.0",
+        "@vue/shared": "3.2.2",
+        "estree-walker": "^2.0.1",
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/vue/node_modules/@vue/compiler-dom": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.2.tgz",
+      "integrity": "sha512-ggcc+NV/ENIE0Uc3TxVE/sKrhYVpLepMAAmEiQ047332mbKOvUkowz4TTFZ+YkgOIuBOPP0XpCxmCMg7p874mA==",
+      "dependencies": {
+        "@vue/compiler-core": "3.2.2",
+        "@vue/shared": "3.2.2"
+      }
+    },
+    "node_modules/vue/node_modules/@vue/shared": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.2.tgz",
+      "integrity": "sha512-dvYb318tk9uOzHtSaT3WII/HscQSIRzoCZ5GyxEb3JlkEXASpAUAQwKnvSe2CudnF8XHFRTB7VITWSnWNLZUtA=="
     },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",
@@ -6801,6 +6845,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.1.tgz",
       "integrity": "sha512-UEJf2ZGww5wGVdrWIXIZo04KdJFGPmI2bHRUsBZ3AdyCAqJ5ykRXKOBn1OR1hvA2YzimudOEyHM+DpbBv91Kww==",
+      "dev": true,
       "requires": {
         "@babel/parser": "^7.12.0",
         "@babel/types": "^7.12.0",
@@ -6813,6 +6858,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.1.tgz",
       "integrity": "sha512-tXg8tkPb3j54zNfWqoao9T1JI41yWPz8TROzmif/QNNA46eq8/SRuRsBd36i47GWaz7mh+yg3vOJ87/YBjcMyQ==",
+      "dev": true,
       "requires": {
         "@vue/compiler-core": "3.2.1",
         "@vue/shared": "3.2.1"
@@ -6859,36 +6905,58 @@
       "integrity": "sha512-quBx4Jjpexo6KDiNUGFr/zF/2A4srKM9S9v2uHgMXSU//hjgq1eGzqkIFql8T9gfX5ZaVOUzYBP3jIdIR3PKIA=="
     },
     "@vue/reactivity": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.1.tgz",
-      "integrity": "sha512-4Lja2KmyiKvuraDed6dXK2A6+r/7x7xGDA7vVR2Aqc8hQVu0+FWeVX+IBfiVOSpbZXFlHLNmCBFkbuWLQSlgxg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.2.tgz",
+      "integrity": "sha512-IHjhtmrhK6dzacj/EnLQDWOaA3HuzzVk6w84qgV8EpS4uWGIJXiRalMRg6XvGW2ykJvIl3pLsF0aBFlTMRiLOA==",
       "requires": {
-        "@vue/shared": "3.2.1"
+        "@vue/shared": "3.2.2"
+      },
+      "dependencies": {
+        "@vue/shared": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.2.tgz",
+          "integrity": "sha512-dvYb318tk9uOzHtSaT3WII/HscQSIRzoCZ5GyxEb3JlkEXASpAUAQwKnvSe2CudnF8XHFRTB7VITWSnWNLZUtA=="
+        }
       }
     },
     "@vue/runtime-core": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.1.tgz",
-      "integrity": "sha512-IsgelRM/5hYeRhz5+ECi66XvYDdjG2t4lARjHvCXw5s9Q4N6uIbjLMwtLzAWRxYf3/y258BrD+ehxAi943ScJg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.2.tgz",
+      "integrity": "sha512-/aUk1+GO/VPX0oVxhbzSWE1zrf3/wGCsO1ALNisVokYftKqfqLDjbJHE6mrI2hx3MiuwbHrWjJClkGUVTIOPEQ==",
       "requires": {
-        "@vue/reactivity": "3.2.1",
-        "@vue/shared": "3.2.1"
+        "@vue/reactivity": "3.2.2",
+        "@vue/shared": "3.2.2"
+      },
+      "dependencies": {
+        "@vue/shared": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.2.tgz",
+          "integrity": "sha512-dvYb318tk9uOzHtSaT3WII/HscQSIRzoCZ5GyxEb3JlkEXASpAUAQwKnvSe2CudnF8XHFRTB7VITWSnWNLZUtA=="
+        }
       }
     },
     "@vue/runtime-dom": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.1.tgz",
-      "integrity": "sha512-bUAHUSe49A5wYdHQ8wsLU1CMPXaG2fRuv2661mx/6Q9+20QxglT3ss8ZeL6AVRu16JNJMcdvTTsNpbnMbVc/lQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.2.tgz",
+      "integrity": "sha512-1Le/NpCfawCOfePfJezvWUF+oCVLU8N+IHN4oFDOxRe6/PgHNJ+yT+YdxFifBfI+TIAoXI/9PsnqzmJZV+xsmw==",
       "requires": {
-        "@vue/runtime-core": "3.2.1",
-        "@vue/shared": "3.2.1",
+        "@vue/runtime-core": "3.2.2",
+        "@vue/shared": "3.2.2",
         "csstype": "^2.6.8"
+      },
+      "dependencies": {
+        "@vue/shared": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.2.tgz",
+          "integrity": "sha512-dvYb318tk9uOzHtSaT3WII/HscQSIRzoCZ5GyxEb3JlkEXASpAUAQwKnvSe2CudnF8XHFRTB7VITWSnWNLZUtA=="
+        }
       }
     },
     "@vue/shared": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.1.tgz",
-      "integrity": "sha512-INN92dVBNgd0TW9BqfQQKx/HWGCHhUUbAV5EZ5FgSCiEdwuZsJbGt1mdnaD9IxGhpiyOjP2ClxGG8SFp7ELcWg=="
+      "integrity": "sha512-INN92dVBNgd0TW9BqfQQKx/HWGCHhUUbAV5EZ5FgSCiEdwuZsJbGt1mdnaD9IxGhpiyOjP2ClxGG8SFp7ELcWg==",
+      "dev": true
     },
     "acorn": {
       "version": "7.4.1",
@@ -8903,12 +8971,12 @@
       "peer": true
     },
     "vite": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.4.4.tgz",
-      "integrity": "sha512-m1wK6pFJKmaYA6AeZIUXyiAgUAAJzVXhIMYCdZUpCaFMGps0v0IlNJtbmPvkUhVEyautalajmnW5X6NboUPsnw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.5.0.tgz",
+      "integrity": "sha512-Dn4B+g54PJsMG5WCc4QeFy1ygMXRdTtFrUPegqfk4+vzVQcbF/DqqmI/1bxezArzbujBJg/67QeT5wz8edfJVQ==",
       "dev": true,
       "requires": {
-        "esbuild": "^0.12.8",
+        "esbuild": "^0.12.17",
         "fsevents": "~2.3.2",
         "postcss": "^8.3.6",
         "resolve": "^1.20.0",
@@ -8930,13 +8998,41 @@
       }
     },
     "vue": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.1.tgz",
-      "integrity": "sha512-0jhXluF5mzTAK5bXw/8yq4McvsI8HwEWI4cnQwJeN8NYGRbwh9wwuE4FNv1Kej9pxBB5ajTNsWr0M6DPs5EJZg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.2.tgz",
+      "integrity": "sha512-D/LuzAV30CgNJYGyNheE/VUs5N4toL2IgmS6c9qeOxvyh0xyn4exyRqizpXIrsvfx34zG9x5gCI2tdRHCGvF9w==",
       "requires": {
-        "@vue/compiler-dom": "3.2.1",
-        "@vue/runtime-dom": "3.2.1",
-        "@vue/shared": "3.2.1"
+        "@vue/compiler-dom": "3.2.2",
+        "@vue/runtime-dom": "3.2.2",
+        "@vue/shared": "3.2.2"
+      },
+      "dependencies": {
+        "@vue/compiler-core": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.2.tgz",
+          "integrity": "sha512-QhCI0ZU5nAR0LMcLgzW3v75374tIrHGp8XG5CzJS7Nsy+iuignbE4MZ2XJfh5TGIrtpuzfWA4eTIfukZf/cRdg==",
+          "requires": {
+            "@babel/parser": "^7.12.0",
+            "@babel/types": "^7.12.0",
+            "@vue/shared": "3.2.2",
+            "estree-walker": "^2.0.1",
+            "source-map": "^0.6.1"
+          }
+        },
+        "@vue/compiler-dom": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.2.tgz",
+          "integrity": "sha512-ggcc+NV/ENIE0Uc3TxVE/sKrhYVpLepMAAmEiQ047332mbKOvUkowz4TTFZ+YkgOIuBOPP0XpCxmCMg7p874mA==",
+          "requires": {
+            "@vue/compiler-core": "3.2.2",
+            "@vue/shared": "3.2.2"
+          }
+        },
+        "@vue/shared": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.2.tgz",
+          "integrity": "sha512-dvYb318tk9uOzHtSaT3WII/HscQSIRzoCZ5GyxEb3JlkEXASpAUAQwKnvSe2CudnF8XHFRTB7VITWSnWNLZUtA=="
+        }
       }
     },
     "vue-i18n": {

--- a/package.json
+++ b/package.json
@@ -16,15 +16,15 @@
     "comlink": "^4.3.1",
     "matercolors": "^2.2.10",
     "notyf": "^3.10.0",
-    "pinia": "^2.0.0-beta.3",
-    "vue": "^3.2.2",
+    "pinia": "^2.0.0-rc.6",
+    "vue": "^3.2.4",
     "vue-i18n": "^9.1.7",
     "vue-router": "^4.0.8"
   },
   "devDependencies": {
     "@intlify/vite-plugin-vue-i18n": "^2.4.0",
     "@vitejs/plugin-vue": "^1.4.0",
-    "@vue/compiler-sfc": "^3.0.5",
+    "@vue/compiler-sfc": "^3.2.4",
     "sass": "^1.34.1",
     "vite": "^2.5.0",
     "vite-plugin-pwa": "^0.8.1"

--- a/package.json
+++ b/package.json
@@ -17,16 +17,16 @@
     "matercolors": "^2.2.10",
     "notyf": "^3.10.0",
     "pinia": "^2.0.0-beta.3",
-    "vue": "^3.0.5",
+    "vue": "^3.2.2",
     "vue-i18n": "^9.1.7",
     "vue-router": "^4.0.8"
   },
   "devDependencies": {
     "@intlify/vite-plugin-vue-i18n": "^2.4.0",
-    "@vitejs/plugin-vue": "^1.2.3",
+    "@vitejs/plugin-vue": "^1.4.0",
     "@vue/compiler-sfc": "^3.0.5",
     "sass": "^1.34.1",
-    "vite": "^2.3.7",
+    "vite": "^2.5.0",
     "vite-plugin-pwa": "^0.8.1"
   }
 }

--- a/src/components/ColorPicker/ColorResult.vue
+++ b/src/components/ColorPicker/ColorResult.vue
@@ -84,14 +84,16 @@ export default {
     column-gap: 16px;
     row-gap: 16px;
 
+    padding: 8px 0;
     justify-items: center;
 
     .video-color--result-empty {
+      grid-column: 2 / 5;
+
       text-align: center;
       width: 100%;
       border-radius: 0.5em;
       padding: 16px;
-      margin: 8px 8px 16px;
       color: var(--darker-color);
       font-size: 14px;
     }
@@ -124,6 +126,10 @@ export default {
 
     .video-color--result-wrapper {
       grid-template-columns: auto auto auto auto;
+
+      .video-color--result-empty {
+        grid-column: 2 / 4;
+      }
 
       .video-color--result-item {
         .result-item--text {

--- a/src/components/ColorPicker/ColorResult.vue
+++ b/src/components/ColorPicker/ColorResult.vue
@@ -78,9 +78,13 @@ export default {
     }
   }
   .video-color--result-wrapper {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: start;
+    display: grid;
+    grid-template-columns: auto auto auto auto auto;
+    grid-auto-columns: 60px;
+    column-gap: 16px;
+    row-gap: 16px;
+
+    justify-items: center;
 
     .video-color--result-empty {
       text-align: center;
@@ -93,8 +97,6 @@ export default {
     }
 
     .video-color--result-item {
-      margin: 0 8px 12px;
-      width: calc((100% / 6) - 3px);
       cursor: pointer;
 
       .result-item--color {
@@ -120,11 +122,13 @@ export default {
     justify-content: center;
     width: calc(100% - 24px);
 
-    .video-color--result-wrapper .video-color--result-item {
-      width: calc((100% / 5) - 1px);
+    .video-color--result-wrapper {
+      grid-template-columns: auto auto auto auto;
 
-      .result-item--text {
-        font-size: 12px;
+      .video-color--result-item {
+        .result-item--text {
+          font-size: 12px;
+        }
       }
     }
   }

--- a/src/services/colors.js
+++ b/src/services/colors.js
@@ -151,11 +151,15 @@ export const calculateColor = async (type, value) => {
       value,
     });
 
-  document.body.style.cssText = cssVariable
-    .filter(([name]) => name.indexOf("gradient") === -1)
+  const lowPriorityCss = ["--dark-color-value", "--darken-color", "--modal-color"];
+  const withoutGradientCss = cssVariable
+    .filter(([name]) => (name.indexOf("gradient") === -1));
+
+  document.body.style.cssText = withoutGradientCss
+    .filter(([name]) => !lowPriorityCss.includes(name))
     .map(([ name, value ]) => `${name}: ${value};`)
     .join("");
-
+    
   if (contrast.result === "black" && !document.body.classList.contains("dark")) {
     document.body.classList.add("dark");
   } else if (contrast.result === "white" && document.body.classList.contains("dark")) {
@@ -167,6 +171,14 @@ export const calculateColor = async (type, value) => {
     contrast,
     gradients,
     variable,
+    nextTick: () => {
+      const variables = withoutGradientCss
+        .filter(([name]) => lowPriorityCss.includes(name));
+
+      variables.forEach(function ([ name, value ]) {
+        document.body.style.setProperty(name, value);
+      });
+    }
   };
 };
 
@@ -195,10 +207,10 @@ export const generateCssColor = async ({ type, value }) => {
     ["primary-color", rgb.toString(colors.rgb)],
     ["secondary-color", secondaryColor],
     ["text-color", textColor],
+    ["contrast-color", contrast.result],
     ["dark-color-value", darkColorValue],
     ["darken-color", gradients[1]],
     ["modal-color", gradients[8]],
-    ["contrast-color", contrast.result],
   ];
 
   cssVariable = cssVariable

--- a/src/views/ColorConvert.vue
+++ b/src/views/ColorConvert.vue
@@ -176,7 +176,7 @@ export default {
       this.gradients = gradients;
     },
     async onColorChanged([id, value]) {
-      const { colors, contrast, gradients, variable } = await calculateColor(
+      const { colors, contrast, gradients, variable, nextTick } = await calculateColor(
         id,
         value
       );
@@ -199,6 +199,8 @@ export default {
           value: this.activeColor.value,
           colors,
         });
+
+        nextTick();
       });
     },
     onColorTypeChanged(id) {

--- a/src/views/ColorPicker.vue
+++ b/src/views/ColorPicker.vue
@@ -1,17 +1,20 @@
 <template>
   <div id="content" class="color-picker--page">
     <VideoPicker />
-    <ColorResult />
+    <Lazy>
+      <ColorResult />
+    </Lazy>
   </div>
 </template>
 
 <script>
+import Lazy from "@src/components/Lazy.vue";
 import ColorResult from "@src/components/ColorPicker/ColorResult.vue";
 import VideoPicker from "@src/components/ColorPicker/VideoPicker.vue";
 
 export default {
   name: "ColorPicker",
-  components: { VideoPicker, ColorResult },
+  components: { VideoPicker, ColorResult, Lazy },
 };
 </script>
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,8 +2,8 @@ import { defineConfig } from "vite";
 import { resolve } from "path";
 import { VitePWA } from "vite-plugin-pwa";
 
-import vue from "@vitejs/plugin-vue";
-import vueI18n from "@intlify/vite-plugin-vue-i18n";
+import Vue from "@vitejs/plugin-vue";
+import VueI18n from "@intlify/vite-plugin-vue-i18n";
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -14,8 +14,8 @@ export default defineConfig({
     },
   },
   plugins: [
-    vue(),
-    vueI18n({
+    Vue(),
+    VueI18n({
       include: resolve(__dirname, "./src/locales/*.json"),
       compositionOnly: true
     }),


### PR DESCRIPTION
## feat/upgrade
- upgrade Vue to v3.2
- upgrade Vite to v2.5
- lazy css variable set, separate the rendering of css variables with low and important priority
- wrap `<ColorResult />` component with `<Lazy />` component