### PR TITLE
fix(color-picker): Color Picker not working on iOS and iPhone (Safari)

### DIFF
--- a/src/components/ColorPicker/VideoPicker.vue
+++ b/src/components/ColorPicker/VideoPicker.vue
@@ -3,6 +3,7 @@
     <div class="video-wrapper--view" :class="`bg-${contrast}-contrast`">
       <video
         autoplay
+        playsinline
         class="video-wrapper--view-video"
         ref="video_ctx"
       ></video>


### PR DESCRIPTION
### Change Log
- update(picker): add extra attribute to video element

### Reference
- #34