### PR TITLE
fix(color-picker): Option to Change Front or Rear Camera is not Available

### DIFF
--- a/src/components/ColorPicker/VideoPicker.vue
+++ b/src/components/ColorPicker/VideoPicker.vue
@@ -68,6 +68,10 @@ export default {
   },
   data() {
     return {
+      size: {
+        width: DEFAULT_WIDTH,
+        height: DEFAULT_HEIGHT
+      },
       isInitialized: false,
       color: [ 33, 33, 33 ],
       interval: null,
@@ -83,8 +87,8 @@ export default {
     return { t };
   },
   mounted() {
-    this.$refs.canvas_ctx.width = DEFAULT_WIDTH;
-    this.$refs.canvas_ctx.height = DEFAULT_HEIGHT;
+    this.$refs.canvas_ctx.width = this.size.width;
+    this.$refs.canvas_ctx.height = this.size.height;
   },
   computed: {
     ...mapState(useAppStore, ["contrast"]),
@@ -201,10 +205,10 @@ export default {
       this.interval = setInterval(() => {
         const ctx = canvas.getContext("2d");
 
-        ctx.drawImage(video, 0, 0, DEFAULT_HEIGHT, DEFAULT_WIDTH);
+        ctx.drawImage(video, 0, 0, this.size.width, this.size.height);
 
-        const sx = DEFAULT_WIDTH / 2;
-        const sy = DEFAULT_HEIGHT / 2;
+        const sx = this.size.width / 2;
+        const sy = this.size.height / 2;
 
         const imageData = ctx.getImageData(sx, sy, 1, 1);
         this.color = imageData.data.slice(0, 3);
@@ -279,6 +283,11 @@ export default {
     },
   },
   activated() {
+    const size = this.getVideoSize();
+    if (size.width !== this.size.width) {
+      this.size = { ...size };
+    }
+
     this.stopVideoStream();
 
     this.color = [ 33, 33, 33 ];


### PR DESCRIPTION
### Intro
What happens now is, when we want to change between the front and rear cameras this can only be done when the permissions have been previously granted. If permission to use the new camera is obtained, the camera that is available by default is only the front camera. To switch to using the rear camera, we have to reload the web page.

It turned out that this was caused by the get available camera device function being called before camera permission was obtained. So by default the browser will only allow the front camera at that time. Only when it is reloaded, with permission to use the existing camera, the browser will provide a list of front and rear camera devices.

So we need to move the function call to get this list of available camera devices, right after the camera is initialized. 

### Change Log
- update(video/picker): move get device lists function after camera initialized.
- fix(video/picker): precision video size

